### PR TITLE
Capture time statistics & docs update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ if (${TRITON_ENABLE_GPU})
     find_package(CUDAToolkit REQUIRED)
 endif ()  # TRITON_ENABLE_GPU
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(src)
 
 add_subdirectory(extern/Catch2)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# -------------------------------------------------- #
+# This is a Docker image dedicated to develop
+# DALI Backend. If you don't want to build the
+# backend together with tritonserver, start from here
+# -------------------------------------------------- #
+
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:20.10-py3
 FROM ${BASE_IMAGE} as builder
 

--- a/client/dali_grpc_client.py
+++ b/client/dali_grpc_client.py
@@ -23,7 +23,7 @@
 
 import argparse, os, sys
 import numpy as np
-import tritongrpcclient
+import tritonclient.grpc
 from PIL import Image
 
 
@@ -110,7 +110,7 @@ def save_byte_image(bytes, size_wh=(224, 224), name_suffix=0):
 def main():
     FLAGS = parse_args()
     try:
-        triton_client = tritongrpcclient.InferenceServerClient(url=FLAGS.url, verbose=FLAGS.verbose)
+        triton_client = tritonclient.grpc.InferenceServerClient(url=FLAGS.url, verbose=FLAGS.verbose)
     except Exception as e:
         print("channel creation failed: " + str(e))
         sys.exit()
@@ -132,8 +132,8 @@ def main():
     output_name = "OUTPUT"
     input_shape = list(image_data.shape)
     input_shape[0] = FLAGS.batch_size
-    inputs.append(tritongrpcclient.InferInput(input_name, input_shape, "UINT8"))
-    outputs.append(tritongrpcclient.InferRequestedOutput(output_name))
+    inputs.append(tritonclient.grpc.InferInput(input_name, input_shape, "UINT8"))
+    outputs.append(tritonclient.grpc.InferRequestedOutput(output_name))
 
     for batch in batcher(image_data, FLAGS.batch_size):
         print("Input mean before backend processing:", np.mean(batch))
@@ -153,10 +153,11 @@ def main():
         for i in range(len(maxs)):
             print("Sample ", i, " - label: ", maxs[i], " ~ ", output0_data[i, maxs[i]])
 
-    statistics = triton_client.get_inference_statistics(model_name=model_name)
+    statistics = triton_client.get_inference_statistics(model_name="dali")
     if len(statistics.model_stats) != 1:
         print("FAILED: Inference Statistics")
         sys.exit(1)
+    print(statistics)
 
     print('PASS: infer')
 

--- a/src/dali_backend.cc
+++ b/src/dali_backend.cc
@@ -397,14 +397,16 @@ TRITONBACKEND_ModelInstanceExecute(
     TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** reqs,
     const uint32_t request_count)
 {
-  TRITONSERVER_Error *error = nullptr;  // success
-  uint64_t exec_start_ns, exec_end_ns, batch_exec_start_ns = -1, batch_exec_end_ns = -1, batch_compute_start_ns = -1, batch_compute_end_ns = -1;
+  TRITONSERVER_Error* error = nullptr;  // success
+  uint64_t exec_start_ns, exec_end_ns,
+      batch_exec_start_ns = -1, batch_exec_end_ns = -1,
+      batch_compute_start_ns = -1, batch_compute_end_ns = -1;
   int total_batch_size = 0;
-  DaliModelInstance *instance_state;
+  DaliModelInstance* instance_state;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceState(
-          instance, reinterpret_cast<void **>(&instance_state)));
-  std::vector<TRITONBACKEND_Request *> requests(reqs, reqs + request_count);
-  std::vector<TRITONBACKEND_Response *> responses(request_count);
+      instance, reinterpret_cast<void**>(&instance_state)));
+  std::vector<TRITONBACKEND_Request*> requests(reqs, reqs + request_count);
+  std::vector<TRITONBACKEND_Response*> responses(request_count);
 
   for (size_t i = 0; i < responses.size(); i++) {
     exec_start_ns = detail::capture_time();
@@ -445,17 +447,17 @@ TRITONBACKEND_ModelInstanceExecute(
     exec_end_ns = detail::capture_time();
 
     RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceReportStatistics(
-            instance, requests[i], !error, exec_start_ns,
-            request_meta.compute_start_ns, request_meta.compute_end_ns,
-            exec_end_ns));
+        instance, requests[i], !error, exec_start_ns,
+        request_meta.compute_start_ns, request_meta.compute_end_ns,
+        exec_end_ns));
 
     RETURN_IF_ERROR(TRITONBACKEND_ResponseSend(
-            responses[i],
-            TRITONSERVER_ResponseCompleteFlag::TRITONSERVER_RESPONSE_COMPLETE_FINAL,
-            error));
+        responses[i],
+        TRITONSERVER_ResponseCompleteFlag::TRITONSERVER_RESPONSE_COMPLETE_FINAL,
+        error));
     RETURN_IF_ERROR(TRITONBACKEND_RequestRelease(
-            requests[i],
-            TRITONSERVER_RequestReleaseFlag::TRITONSERVER_REQUEST_RELEASE_ALL));
+        requests[i],
+        TRITONSERVER_RequestReleaseFlag::TRITONSERVER_REQUEST_RELEASE_ALL));
 
     total_batch_size += request_meta.batch_size;
     batch_exec_end_ns = exec_end_ns;
@@ -463,8 +465,8 @@ TRITONBACKEND_ModelInstanceExecute(
   }
 
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceReportBatchStatistics(
-          instance, total_batch_size, batch_exec_start_ns, batch_compute_start_ns,
-          batch_compute_end_ns, batch_exec_end_ns));
+      instance, total_batch_size, batch_exec_start_ns, batch_compute_start_ns,
+      batch_compute_end_ns, batch_exec_end_ns));
 
   return nullptr;
 }

--- a/src/dali_backend.cc
+++ b/src/dali_backend.cc
@@ -395,21 +395,24 @@ TRITONBACKEND_ModelInstanceExecute(
     TRITONBACKEND_ModelInstance* instance, TRITONBACKEND_Request** reqs,
     const uint32_t request_count)
 {
-  TRITONSERVER_Error* error = nullptr;  // success
-  DaliModelInstance* instance_state;
+  TRITONSERVER_Error *error = nullptr;  // success
+  uint64_t exec_start_ns, exec_end_ns;
+  DaliModelInstance *instance_state;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceState(
-      instance, reinterpret_cast<void**>(&instance_state)));
-  std::vector<TRITONBACKEND_Request*> requests(reqs, reqs + request_count);
-  std::vector<TRITONBACKEND_Response*> responses(request_count);
+          instance, reinterpret_cast<void **>(&instance_state)));
+  std::vector<TRITONBACKEND_Request *> requests(reqs, reqs + request_count);
+  std::vector<TRITONBACKEND_Response *> responses(request_count);
 
   for (size_t i = 0; i < responses.size(); i++) {
+    exec_start_ns = detail::capture_time();
     // TODO Do not process requests one by one, but gather all
     //     into one buffer and process it in DALI all together
     RETURN_IF_ERROR(TRITONBACKEND_ResponseNew(&responses[i], requests[i]));
+    detail::RequestMeta request_meta;
 
     try {
-      detail::ProcessRequest(
-          responses[i], requests[i], instance_state->GetDaliExecutor());
+      request_meta = detail::ProcessRequest(responses[i], requests[i],
+                                            instance_state->GetDaliExecutor());
     }
     catch (DaliBackendException& e) {
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (e.what()));
@@ -426,23 +429,29 @@ TRITONBACKEND_ModelInstanceExecute(
     catch (std::runtime_error& e) {
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, (e.what()));
       error = TRITONSERVER_ErrorNew(
-          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN,
-          make_string("runtime error: ", e.what()).c_str());
+              TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN,
+              make_string("runtime error: ", e.what()).c_str());
     }
     catch (...) {
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, ("Unknown error"));
       error = TRITONSERVER_ErrorNew(
-          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN,
-          "Unknown DALI Backend error");
+              TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN,
+              "Unknown DALI Backend error");
     }
 
+    exec_end_ns = detail::capture_time();
+
+    RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceReportStatistics(
+            instance, requests[i], !error, exec_start_ns, request_meta.compute_start_ns,
+            request_meta.compute_end_ns, exec_end_ns));
+
     RETURN_IF_ERROR(TRITONBACKEND_ResponseSend(
-        responses[i],
-        TRITONSERVER_ResponseCompleteFlag::TRITONSERVER_RESPONSE_COMPLETE_FINAL,
-        error));
+            responses[i],
+            TRITONSERVER_ResponseCompleteFlag::TRITONSERVER_RESPONSE_COMPLETE_FINAL,
+            error));
     RETURN_IF_ERROR(TRITONBACKEND_RequestRelease(
-        requests[i],
-        TRITONSERVER_RequestReleaseFlag::TRITONSERVER_REQUEST_RELEASE_ALL));
+            requests[i],
+            TRITONSERVER_RequestReleaseFlag::TRITONSERVER_REQUEST_RELEASE_ALL));
   }
   return nullptr;
 }

--- a/src/dali_backend.h
+++ b/src/dali_backend.h
@@ -188,7 +188,9 @@ ProcessRequest(
   RequestMeta ret;
 
   auto dali_inputs = GenerateInputs(request);
-  ret.batch_size = dali_inputs[0].shape.num_samples();  // Batch size is expected to be the same in every input
+  ret.batch_size =
+      dali_inputs[0].shape.num_samples();  // Batch size is expected to be the
+                                           // same in every input
 
   ret.compute_start_ns = capture_time();
   auto shapes_and_types = executor.Run(dali_inputs);

--- a/src/dali_backend.h
+++ b/src/dali_backend.h
@@ -176,6 +176,7 @@ AllocateOutputs(
 
 struct RequestMeta {
   uint64_t compute_start_ns, compute_end_ns;
+  int batch_size;
 };
 
 
@@ -187,6 +188,7 @@ ProcessRequest(
   RequestMeta ret;
 
   auto dali_inputs = GenerateInputs(request);
+  ret.batch_size = dali_inputs[0].shape.num_samples();  // Batch size is expected to be the same in every input
 
   ret.compute_start_ns = capture_time();
   auto shapes_and_types = executor.Run(dali_inputs);

--- a/src/dali_backend.h
+++ b/src/dali_backend.h
@@ -23,8 +23,9 @@
 #ifndef DALI_BACKEND_DALI_BACKEND_H
 #define DALI_BACKEND_DALI_BACKEND_H
 
-#include <numeric>
 #include <chrono>
+#include <numeric>
+
 #include "src/dali_executor/dali_executor.h"
 #include "src/error_handling.h"
 #include "src/model_provider/model_provider.h"
@@ -82,13 +83,16 @@ to_dali(TRITONSERVER_MemoryType t)
 }
 
 
-inline uint64_t capture_time() {
+inline uint64_t
+capture_time()
+{
   return std::chrono::steady_clock::now().time_since_epoch().count();
 }
 
 
 std::vector<InputDescriptor>
-GenerateInputs(TRITONBACKEND_Request *request) {
+GenerateInputs(TRITONBACKEND_Request* request)
+{
   uint32_t input_cnt;
   TRITON_CALL_GUARD(TRITONBACKEND_RequestInputCount(request, &input_cnt));
   std::vector<InputDescriptor> ret(input_cnt);
@@ -151,20 +155,20 @@ AllocateOutputs(
     auto output_shape = array_shape(snt.shape);
     TRITONBACKEND_Output* triton_output;
     TRITONBACKEND_ResponseOutput(
-            response, &triton_output, name, to_triton(snt.type),
-            output_shape.data(), output_shape.size());
-    void *buffer;
+        response, &triton_output, name, to_triton(snt.type),
+        output_shape.data(), output_shape.size());
+    void* buffer;
     TRITONSERVER_MemoryType memtype;
     int64_t memid;
     auto buffer_byte_size = std::accumulate(
-            output_shape.begin(), output_shape.end(), 1,
-            std::multiplies<int>()) *
+                                output_shape.begin(), output_shape.end(), 1,
+                                std::multiplies<int>()) *
                             TRITONSERVER_DataTypeByteSize(to_triton(snt.type));
     TRITON_CALL_GUARD(TRITONBACKEND_OutputBuffer(
-            triton_output, &buffer, buffer_byte_size, &memtype, &memid));
+        triton_output, &buffer, buffer_byte_size, &memtype, &memid));
     output_desc.device = to_dali(memtype);
     output_desc.buffer =
-            make_span(reinterpret_cast<char *>(buffer), buffer_byte_size);
+        make_span(reinterpret_cast<char*>(buffer), buffer_byte_size);
   }
   return ret;
 }
@@ -175,8 +179,11 @@ struct RequestMeta {
 };
 
 
-RequestMeta ProcessRequest(TRITONBACKEND_Response *response, TRITONBACKEND_Request *request,
-                           DaliExecutor &executor) {
+RequestMeta
+ProcessRequest(
+    TRITONBACKEND_Response* response, TRITONBACKEND_Request* request,
+    DaliExecutor& executor)
+{
   RequestMeta ret;
 
   auto dali_inputs = GenerateInputs(request);

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "src/dali_executor/dali_executor.h"
+
 #include "src/dali_executor/utils/dali.h"
 
 namespace triton { namespace backend { namespace dali {

--- a/src/dali_executor/dali_executor.h
+++ b/src/dali_executor/dali_executor.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "src/dali_executor/pipeline_group.h"
 #include "src/dali_executor/pipeline_pool.h"
 #include "src/dali_executor/utils/dali.h"

--- a/src/dali_executor/dali_pipeline.cc
+++ b/src/dali_executor/dali_pipeline.cc
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "src/dali_executor/dali_pipeline.h"
+
 #include <memory>
 
 namespace triton { namespace backend { namespace dali {

--- a/src/dali_executor/dali_pipeline.h
+++ b/src/dali_executor/dali_pipeline.h
@@ -23,6 +23,7 @@
 #ifndef DALI_BACKEND_DALI_EXECUTOR_DALI_PIPELINE_H_
 #define DALI_BACKEND_DALI_EXECUTOR_DALI_PIPELINE_H_
 
+#include <mutex>
 #include <string>
 #include <vector>
 

--- a/src/dali_executor/dali_pipeline.h
+++ b/src/dali_executor/dali_pipeline.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+
 #include "src/dali_executor/utils/dali.h"
 #include "src/dali_executor/utils/utils.h"
 #include "src/error_handling.h"

--- a/src/dali_executor/executor.test.cc
+++ b/src/dali_executor/executor.test.cc
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <catch2/catch.hpp>
+
 #include "src/dali_executor/dali_executor.h"
 #include "src/dali_executor/serialized_pipelines.h"
 #include "src/dali_executor/test/test_utils.h"

--- a/src/dali_executor/pipeline_group.cc
+++ b/src/dali_executor/pipeline_group.cc
@@ -21,7 +21,9 @@
 // SOFTWARE.
 
 #include "src/dali_executor/pipeline_group.h"
+
 #include <numeric>
+
 #include "src/dali_executor/utils/dali.h"
 
 namespace triton { namespace backend { namespace dali {

--- a/src/dali_executor/pipeline_group.h
+++ b/src/dali_executor/pipeline_group.h
@@ -25,6 +25,7 @@
 
 #include <utility>
 #include <vector>
+
 #include "src/dali_executor/dali_pipeline.h"
 
 namespace triton { namespace backend { namespace dali {

--- a/src/dali_executor/pipeline_pool.h
+++ b/src/dali_executor/pipeline_pool.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "src/dali_executor/dali_pipeline.h"
 #include "src/dali_executor/pipeline_group.h"
 
@@ -63,8 +64,8 @@ struct PipelineDescr {
 namespace std {
 template <>
 struct hash<triton::backend::dali::PipelineDescr> {
-  size_t operator()(triton::backend::dali::PipelineDescr const& pk) const
-      noexcept
+  size_t operator()(
+      triton::backend::dali::PipelineDescr const& pk) const noexcept
   {
     return pk.serialized_pipeline_hash ^ static_cast<size_t>(pk.batch_size);
   }

--- a/src/dali_executor/test/test_utils.h
+++ b/src/dali_executor/test/test_utils.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+
 #include "src/dali_executor/dali_executor.h"
 
 namespace triton { namespace backend { namespace dali { namespace test {

--- a/src/dali_executor/utils/utils.h
+++ b/src/dali_executor/utils/utils.h
@@ -24,6 +24,7 @@
 #define DALI_BACKEND_UTILS_UTILS_H_
 
 #include <cuda_runtime_api.h>
+
 #include "nvtx3/nvToolsExt.h"
 
 namespace triton { namespace backend { namespace dali {


### PR DESCRIPTION
TODO:
- [x] Test if solution works
- [x] Wait for https://github.com/triton-inference-server/common/tree/davidg-format to be merged
- [x] Reformat code with `clang-format`

A few things happen in this PR:
- DALI Backend from now on will gather time statistics and report them via clients
- Small description of the docker image, handy for development
- Code base has been formatted according to triton-inference-server practise
- Updating supplied client to `tritonserver:20.10-client-py3`
- Small fixes due to gcc upgrade (proper to ubuntu20)

Signed-off-by: szalpal <mszolucha@nvidia.com>