### PR TITLE
Init TRITONBACKEND_OutputBuffer arguments that also serve as input

### DIFF
--- a/src/dali_backend.h
+++ b/src/dali_backend.h
@@ -158,8 +158,8 @@ AllocateOutputs(
         response, &triton_output, name, to_triton(snt.type),
         output_shape.data(), output_shape.size());
     void* buffer;
-    TRITONSERVER_MemoryType memtype;
-    int64_t memid;
+    TRITONSERVER_MemoryType memtype = TRITONSERVER_MEMORY_CPU_PINNED;
+    int64_t memid = 0;
     auto buffer_byte_size = std::accumulate(
                                 output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>()) *


### PR DESCRIPTION
mem_type and mem_type_id specifies the preferred value when TRITONBACKEND_OutputBuffer reads them as input