### PR TITLE
Update docs & change preferred output memory type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+##### **NOTE:** `dali_backend` is available in `tritonserver-20.11` and later
+
 # DALI TRITON Backend
 
 This repository contains code for DALI Backend for Triton Inference Server.
@@ -90,9 +92,10 @@ group for DALI model.
 ## How to build?
 
 ### Docker build
-To build DALI Backend using docker, it's as simple as
+Building DALI Backend with docker is as simple as:
 
-    cd <repo>
+    git clone --recursive https://github.com/triton-inference-server/dali_backend.git
+    cd dali_backend 
     docker build .
 
 ### Bare metal
@@ -118,3 +121,5 @@ Building DALI Backend is really straightforward. One thing to remember is to clo
     
 The building process will generate `unittest` executable.
 You can use it to run unit tests for DALI Backend
+
+

--- a/src/dali_backend.h
+++ b/src/dali_backend.h
@@ -174,7 +174,7 @@ AllocateOutputs(
         response, &triton_output, name, to_triton(snt.type),
         output_shape.data(), output_shape.size()));
     void* buffer;
-    TRITONSERVER_MemoryType memtype = TRITONSERVER_MEMORY_CPU_PINNED;
+    TRITONSERVER_MemoryType memtype = TRITONSERVER_MEMORY_GPU;
     int64_t memid = 0;
     auto buffer_byte_size = std::accumulate(
                                 output_shape.begin(), output_shape.end(), 1,


### PR DESCRIPTION
This PR updates docs with info of first `tritonserver` version `dali_backend` is available in and changes preferred output memory type from DALI backend to GPU

Signed-off-by: szalpal <mszolucha@nvidia.com>