### PR TITLE
Specify tritonserver address:port in test scripts

### DIFF
--- a/qa/L0_identity/test.sh
+++ b/qa/L0_identity/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+GRPC_ADDR:=${1:-"localhost:8001"}
 
 python identity_client.py -u $GRPC_ADDR

--- a/qa/L0_identity/test.sh
+++ b/qa/L0_identity/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-GRPC_ADDR:=${1:-"localhost:8001"}
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
 
 python identity_client.py -u $GRPC_ADDR

--- a/qa/L0_identity/test.sh
+++ b/qa/L0_identity/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
 
-echo "Test run"
-python identity_client.py
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+
+python identity_client.py -u $GRPC_ADDR

--- a/qa/L0_inception_ensemble/test.sh
+++ b/qa/L0_inception_ensemble/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+GRPC_ADDR:=${1:-"localhost:8001"}
 
 python ensemble_client.py --batch_size 64 --n_iter 3 --model_name ensemble_dali_inception --img_dir images -u $GRPC_ADDR

--- a/qa/L0_inception_ensemble/test.sh
+++ b/qa/L0_inception_ensemble/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-GRPC_ADDR:=${1:-"localhost:8001"}
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
 
 python ensemble_client.py --batch_size 64 --n_iter 3 --model_name ensemble_dali_inception --img_dir images -u $GRPC_ADDR

--- a/qa/L0_inception_ensemble/test.sh
+++ b/qa/L0_inception_ensemble/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
 
-echo "Run test"
-python ensemble_client.py --batch_size 64 --n_iter 3 --model_name ensemble_dali_inception --img_dir images
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+
+python ensemble_client.py --batch_size 64 --n_iter 3 --model_name ensemble_dali_inception --img_dir images -u $GRPC_ADDR

--- a/qa/L0_multi_input/test.sh
+++ b/qa/L0_multi_input/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+GRPC_ADDR:=${1:-"localhost:8001"}
 
 python multi_input_client.py --batch_size 256 --n_iter 7 -u $GRPC_ADDR

--- a/qa/L0_multi_input/test.sh
+++ b/qa/L0_multi_input/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
 
-echo "Test run"
-python multi_input_client.py --batch_size 256 --n_iter 7
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+
+python multi_input_client.py --batch_size 256 --n_iter 7 -u $GRPC_ADDR

--- a/qa/L0_multi_input/test.sh
+++ b/qa/L0_multi_input/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
 
-GRPC_ADDR:=${1:-"localhost:8001"}
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
 
 python multi_input_client.py --batch_size 256 --n_iter 7 -u $GRPC_ADDR


### PR DESCRIPTION
Relates to !26

This PR aims at allowing to specify `address:port` of the server, where the tests are run.

Usage of bash idiom:
```bash
GRPC_ADDR='localhost:8001' bash test.sh
```

Signed-off-by: szalpal <mszolucha@nvidia.com>