### PR TITLE
Pick Triton version during docker image  build

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -26,7 +26,7 @@
 # -------------------------------------------------- #
 
 ARG TRITON_VERSION=21.04
-ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:21.04-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 FROM ${BASE_IMAGE} as builder
 
 RUN apt-get update                                && \
@@ -75,9 +75,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
       -D CMAKE_BUILD_TYPE=Debug                       \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                 \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
-      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"  \
-      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"    \
-      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" \
+      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
+      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
+      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION"   \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -73,9 +73,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
       -D CMAKE_BUILD_TYPE=Debug                       \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                 \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
-      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"  \
-      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"    \
-      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" \
+      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"  \
+      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"    \
+      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -25,6 +25,7 @@
 # backend together with tritonserver, start from here
 # -------------------------------------------------- #
 
+ARG TRITON_VERSION=21.04
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:21.04-py3
 FROM ${BASE_IMAGE} as builder
 
@@ -72,6 +73,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
       -D CMAKE_BUILD_TYPE=Debug                       \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                 \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
+      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"  \
+      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"    \
+      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -67,6 +67,8 @@ WORKDIR /dali
 
 COPY . .
 
+ARG TRITON_VERSION
+
 RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D WERROR=OFF                                   \

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -72,9 +72,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
       -D CMAKE_BUILD_TYPE=Release                     \
-      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"     \
-      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"      \
-      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}"    \
+      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"  \
+      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"    \
+      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -68,13 +68,15 @@ WORKDIR /dali
 
 COPY . .
 
+ARG TRITON_VERSION
+
 RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
       -D CMAKE_BUILD_TYPE=Release                     \
-      -D TRITON_COMMON_REPO_TAG="r21.04"  \
-      -D TRITON_CORE_REPO_TAG="r21.04"    \
-      -D TRITON_BACKEND_REPO_TAG="r21.04" \
+      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"  \
+      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"    \
+      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -26,6 +26,7 @@
 # the whole tritonserver, start from here.
 # -------------------------------------------------- #
 
+ARG TRITON_VERSION=21.04
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:21.04-py3
 FROM ${BASE_IMAGE} as builder
 
@@ -71,6 +72,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
       -D CMAKE_BUILD_TYPE=Release                     \
+      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"     \
+      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"      \
+      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}"    \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -27,7 +27,7 @@
 # -------------------------------------------------- #
 
 ARG TRITON_VERSION=21.04
-ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:21.04-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 FROM ${BASE_IMAGE} as builder
 
 RUN apt-get update                                && \
@@ -74,9 +74,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
       -D CMAKE_BUILD_TYPE=Release                     \
-      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"  \
-      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"    \
-      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION" \
+      -D TRITON_COMMON_REPO_TAG="r$TRITON_VERSION"    \
+      -D TRITON_CORE_REPO_TAG="r$TRITON_VERSION"      \
+      -D TRITON_BACKEND_REPO_TAG="r$TRITON_VERSION"   \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -72,9 +72,9 @@ RUN mkdir build_in_ci && cd build_in_ci && \
     cmake                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver       \
       -D CMAKE_BUILD_TYPE=Release                     \
-      -D TRITON_COMMON_REPO_TAG="r${TRITON_VERSION}"  \
-      -D TRITON_CORE_REPO_TAG="r${TRITON_VERSION}"    \
-      -D TRITON_BACKEND_REPO_TAG="r${TRITON_VERSION}" \
+      -D TRITON_COMMON_REPO_TAG="r21.04"  \
+      -D TRITON_CORE_REPO_TAG="r21.04"    \
+      -D TRITON_BACKEND_REPO_TAG="r21.04" \
       .. &&                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 


### PR DESCRIPTION
At this point, we were picking upstream Triton API version for building dali_backend, while deploying dali_backend into the last released version of `tritonserver`. This spawned a problem, when upstream bumped up API version: `dali_backend` suddenly had API version `1.2`, while the image we're deploying to had still `1.0`. And `tritonserver` API version has to be higher or equal to backend API version. 

This PR allows to pick manually Triton API version when building `dali_backend`