### PR TITLE
Check external source backend to optimize intermediate buffer allocation.

### DIFF
--- a/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
+++ b/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
@@ -26,8 +26,8 @@ import argparse
 
 @dali.pipeline_def(batch_size=1, num_threads=min(mp.cpu_count(), 4), device_id=0)
 def pipeline():
-  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0', no_copy=True)
-  inp2 = fn.external_source(device='cpu', name='DALI_INPUT_1', no_copy=True)
+  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
+  inp2 = fn.external_source(device='cpu', name='DALI_INPUT_1')
   return inp1 * 2, fn.cast(inp2.gpu() * 3, dtype=dali.types.FLOAT16)
 
 

--- a/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
+++ b/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
@@ -28,7 +28,7 @@ import argparse
 def pipeline():
   inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
   inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1')
-  return inp1 * 2, fn.cast(inp2 * 3, dtype=dali.types.FLOAT16)
+  return inp1.gpu() * 2, fn.cast(inp2 * 3, dtype=dali.types.FLOAT16)
 
 
 def main(filename):

--- a/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
+++ b/qa/L0_DALI_GPU_ensemble/model_repository/dali_1/pipeline.py
@@ -27,8 +27,8 @@ import argparse
 @dali.pipeline_def(batch_size=1, num_threads=min(mp.cpu_count(), 4), device_id=0)
 def pipeline():
   inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
-  inp2 = fn.external_source(device='cpu', name='DALI_INPUT_1')
-  return inp1 * 2, fn.cast(inp2.gpu() * 3, dtype=dali.types.FLOAT16)
+  inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1')
+  return inp1 * 2, fn.cast(inp2 * 3, dtype=dali.types.FLOAT16)
 
 
 def main(filename):

--- a/qa/L0_DALI_GPU_ensemble/model_repository/dali_2/pipeline.py
+++ b/qa/L0_DALI_GPU_ensemble/model_repository/dali_2/pipeline.py
@@ -26,9 +26,9 @@ import argparse
 
 @dali.pipeline_def(batch_size=1, num_threads=min(mp.cpu_count(), 4), device_id=0)
 def pipeline():
-  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
+  inp1 = fn.external_source(device='gpu', name='DALI_INPUT_0')
   inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1')
-  return inp1.gpu() / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
+  return inp1 / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
 
 
 def main(filename):

--- a/qa/L0_DALI_GPU_ensemble/model_repository/dali_2/pipeline.py
+++ b/qa/L0_DALI_GPU_ensemble/model_repository/dali_2/pipeline.py
@@ -26,9 +26,9 @@ import argparse
 
 @dali.pipeline_def(batch_size=1, num_threads=min(mp.cpu_count(), 4), device_id=0)
 def pipeline():
-  inp1 = fn.external_source(device='gpu', name='DALI_INPUT_0')
+  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
   inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1')
-  return inp1 / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
+  return inp1.gpu() / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
 
 
 def main(filename):

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -75,7 +75,9 @@ IOBufferI* DaliExecutor::GetOutputBuffer(const std::string& name, device_type_t 
 
 IDescr DaliExecutor::ScheduleInputCopy(const IDescr& input) {
   assert(input.buffers.size() > 0);
-  IOBufferI* buffer = GetInputBuffer(input.meta.name, input.buffers[0].device);
+  auto input_name = input.meta.name;
+  auto input_device = pipeline_.GetInputDevice(input_name);
+  IOBufferI* buffer = GetInputBuffer(input_name, input_device);
   size_t size = 0;
   for (auto& buf : input.buffers)
     size += buf.size;

--- a/src/dali_executor/dali_executor.h
+++ b/src/dali_executor/dali_executor.h
@@ -82,7 +82,7 @@ class DaliExecutor {
   /**
    * @brief Check if an input can be used without a copy.
    */
-  bool IsNoCopy(const IDescr& input);
+  bool IsNoCopy(device_type_t es_device, const IDescr& input);
 
   int GetNumThreads() {
     auto n_threads = pipeline_.NumThreadsArg();

--- a/src/dali_executor/dali_pipeline.h
+++ b/src/dali_executor/dali_pipeline.h
@@ -112,15 +112,19 @@ class DaliPipeline {
     return daliGetOutputDevice(&handle_, output_idx);
   }
 
+  device_type_t GetInputDevice(const std::string& name);
+
   std::vector<TensorListShape<>> GetOutputShapes();
 
   void SetInput(const void* data_ptr, const char* name, device_type_t source_device,
-                dali_data_type_t data_type, span<const int64_t> inputs_shapes, int sample_ndims);
+                dali_data_type_t data_type, span<const int64_t> inputs_shapes, int sample_ndims,
+                bool force_no_copy = true);
 
   void SetInput(const void* ptr, const char* name, device_type_t source_device,
-                dali_data_type_t data_type, TensorListShape<> input_shape);
+                dali_data_type_t data_type, TensorListShape<> input_shape,
+                bool force_no_copy = true);
 
-  void SetInput(const IDescr& io_descr);
+  void SetInput(const IDescr& io_descr, bool force_no_copy = true);
 
   void PutOutput(void* destination, int output_idx, device_type_t destination_device);
 
@@ -156,7 +160,7 @@ class DaliPipeline {
       for (const auto& path : plugin_paths) {
         daliLoadLibrary(path.c_str());
       }
-    } catch (const std::exception &e) {
+    } catch (const std::exception& e) {
       throw DaliBackendException(e.what());
     } catch (...) {
       throw DaliBackendException("Unknown error");

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -23,6 +23,8 @@
 #ifndef DALI_BACKEND_UTILS_UTILS_H_
 #define DALI_BACKEND_UTILS_UTILS_H_
 
+#include <vector>
+#include <string>
 
 namespace triton { namespace backend { namespace dali {
 

--- a/src/utils/utils.test.cc
+++ b/src/utils/utils.test.cc
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "src/utils/utils.h"
 #include <catch2/catch.hpp>
 #include <iostream>
-#include "src/utils/utils.h"
 
 namespace triton { namespace backend { namespace dali { namespace test {
 

--- a/src/utils/utils.test.cc
+++ b/src/utils/utils.test.cc
@@ -20,9 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "src/utils/utils.h"
 #include <catch2/catch.hpp>
 #include <iostream>
+
+#include "src/utils/utils.h"
 
 namespace triton { namespace backend { namespace dali { namespace test {
 


### PR DESCRIPTION
I check the backend of an external source to allocate an intermediate buffer on the same device. Due to that I can force no_copy mode when setting the input. 