### PR TITLE
Specify DALI version as build argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,23 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
-set(DALI_VERSION CACHE STRING "")
-message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
+set(DALI_VERSION "" CACHE STRING
+        "DALI version that should be downloaded by the build system.
+         By default the latest available DALI version will be downloaded.
+         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
+)
+set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+        "URL of the Index, from which DALI will be downloaded by the build system.
+         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
+)
+set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
+        "Extra options for `pip download` call, that downloads DALI wheel.
+         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
+)
+if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
+    message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
+    message(STATUS "Downloading DALI from: ${DALI_EXTRA_INDEX_URL}")
+endif ()
 
 
 # Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
+set(DALI_VERSION CACHE STRING "")
+message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
+
 
 # Dependencies
 #

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -33,7 +33,8 @@ include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download -d ${CMAKE_CURRENT_BINARY_DIR} --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda110
+        pip download -d ${CMAKE_CURRENT_BINARY_DIR} --extra-index-url https://developer.download.nvidia.com/compute/redist
+        nvidia-dali-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
     COMMAND touch dali_whl  # So that this command won't be re-run every time

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -26,14 +26,12 @@ set(
         io_buffer.cc
 )
 
-
-
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download -d ${CMAKE_CURRENT_BINARY_DIR} --extra-index-url https://developer.download.nvidia.com/compute/redist
+        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
         nvidia-dali-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali


### PR DESCRIPTION
This PR allows specifying DALI version during dali_backend build is the following way:
```bash
cmake -D DALI_VERSION=1.4 [...]
```

Signed-off-by: szalpal <mszolucha@nvidia.com>