### PR TITLE
Working around build error from libcudacxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif ()  # TRITON_ENABLE_GPU
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-local-typedefs")
 
 if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")


### PR DESCRIPTION
In latest release, libcudacxx prompts a build error, that a typedef is unused:
```
/cuda/memory_resource:818:13: error: typedef ‘using __view1_t = class cuda::__4::basic_resource_view<_ResourcePointer, _Properties>’ locally defined but not used [-Werror=unused-local-typedefs]
  818 |       using __view1_t = basic_resource_view;
```

This PR turns off this warning. It may be reverted, when the problem in libcudacxx is fixed.

Signed-off-by: szalpal <mszolucha@nvidia.com>

