### PR TITLE
Change perf_analyzer test configuration

### DIFF
--- a/qa/L0_perf_analyzer_example/test.sh
+++ b/qa/L0_perf_analyzer_example/test.sh
@@ -23,6 +23,8 @@
 
 : ${GRPC_ADDR:=${1:-"localhost:8001"}}
 
-perf_analyzer -m dali -i grpc -u $GRPC_ADDR -b 64 --input-data test_image --shape DALI_INPUT_0:`stat --printf="%s" test_image/DALI_INPUT_0` -f results.txt
+perf_analyzer -m dali -i grpc -u $GRPC_ADDR -b 64 --input-data test_image \
+              --shape DALI_INPUT_0:`stat --printf="%s" test_image/DALI_INPUT_0` -f results.txt \
+              --measurement-mode count_windows --measurement-request-count 100
 # Test if the perf_analyzer output is in a proper format and the measured times are in a reasonable range.
 [[ `tail -n1 results.txt` =~ ^1,[0-9]{3}\.[0-9],([0-9]{1,6},){10}[0-9]{1,6}$ ]] && echo "Output Correct"


### PR DESCRIPTION
Sometimes in the `perf_analyzer_example`, `perf_analyzer` fails to stabilize the throughput and latency throughout the timed window (`5000ms`). Therefore I'm changing that to always run `100` windows - should fix the issue.

Signed-off-by: szalpal <mszolucha@nvidia.com>