### PR TITLE
Add NVTX markers for DALI Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 option(WERROR "Trigger error on warnings" OFF)
 
+# Don't update the TRITON_BACKEND_API_VERSION unless necessary.
+# We want to use as-old-as-possible version.
 set(TRITON_BACKEND_API_VERSION "r21.05" CACHE STRING "Triton backend API tag")
 set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")

--- a/src/dali_backend.cc
+++ b/src/dali_backend.cc
@@ -35,6 +35,7 @@ extern "C" {
 // should initialize any global state that is intended to be shared
 // across all models and model instances that use the backend.
 TRITONSERVER_Error* TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend) {
+  TimeRange tr("[DALI BE] Initialize", TimeRange::kNavy);
   const char* cname;
   RETURN_IF_ERROR(TRITONBACKEND_BackendName(backend, &cname));
   std::string name(cname);
@@ -90,6 +91,7 @@ TRITONSERVER_Error* TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend) {
 // using TRITONBACKEND_BackendSetState. The backend must free this
 // state and perform any other global cleanup.
 TRITONSERVER_Error* TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend) {
+  TimeRange tr("[DALI BE] Finalize", TimeRange::kNavy);
   void* vstate;
   RETURN_IF_ERROR(TRITONBACKEND_BackendState(backend, &vstate));
   std::string* state = reinterpret_cast<std::string*>(vstate);
@@ -106,6 +108,7 @@ TRITONSERVER_Error* TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend) {
 // should initialize any state that is intended to be shared across
 // all instances of the model.
 TRITONSERVER_Error* TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model) {
+  TimeRange tr("[DALI BE] ModelInitialize", TimeRange::kNavy);
   const char* cname;
   RETURN_IF_ERROR(TRITONBACKEND_ModelName(model, &cname));
   std::string name(cname);
@@ -158,6 +161,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model) {
 // is set using TRITONBACKEND_ModelSetState. The backend must free
 // this state and perform any other cleanup.
 TRITONSERVER_Error* TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model) {
+  TimeRange tr("[DALI BE] ModelFinalize", TimeRange::kNavy);
   void* vstate;
   RETURN_IF_ERROR(TRITONBACKEND_ModelState(model, &vstate));
   DaliModel* model_state = reinterpret_cast<DaliModel*>(vstate);
@@ -173,6 +177,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model) {
 // backend should initialize any state that is required for a model
 // instance.
 TRITONSERVER_Error* TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance) {
+  TimeRange tr("[DALI BE] ModelInstanceInitialize", TimeRange::kNavy);
   const char* cname;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceName(instance, &cname));
   std::string name(cname);
@@ -210,6 +215,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelIns
 // state is set using TRITONBACKEND_ModelInstanceSetState. The backend
 // must free this state and perform any other cleanup.
 TRITONSERVER_Error* TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance) {
+  TimeRange tr("[DALI BE] ModelInstanceFinalize", TimeRange::kNavy);
   void* vstate;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceState(instance, &vstate));
   DaliModelInstance* instance_state = reinterpret_cast<DaliModelInstance*>(vstate);

--- a/src/dali_backend.cc
+++ b/src/dali_backend.cc
@@ -224,7 +224,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInsta
 TRITONSERVER_Error* TRITONBACKEND_ModelInstanceExecute(TRITONBACKEND_ModelInstance* instance,
                                                        TRITONBACKEND_Request** reqs,
                                                        const uint32_t request_count) {
-  TimeRange tr("[DALI BE] ModelInstanceExecute");
+  TimeRange tr("[DALI BE] ModelInstanceExecute", TimeRange::kNavy);
   std::vector<TritonRequest> requests;
   for (uint32_t idx = 0; idx < request_count; ++idx) {
     requests.emplace_back(reqs[idx]);

--- a/src/dali_backend.cc
+++ b/src/dali_backend.cc
@@ -224,6 +224,7 @@ TRITONSERVER_Error* TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInsta
 TRITONSERVER_Error* TRITONBACKEND_ModelInstanceExecute(TRITONBACKEND_ModelInstance* instance,
                                                        TRITONBACKEND_Request** reqs,
                                                        const uint32_t request_count) {
+  TimeRange tr("[DALI BE] ModelInstanceExecute");
   std::vector<TritonRequest> requests;
   for (uint32_t idx = 0; idx < request_count; ++idx) {
     requests.emplace_back(reqs[idx]);

--- a/src/dali_executor/utils/utils.h
+++ b/src/dali_executor/utils/utils.h
@@ -127,22 +127,13 @@ struct NvtxDomain {
 
 // Basic timerange for profiling
 struct TimeRange {
-  static const uint32_t kRed = 0xFF0000;
-  static const uint32_t kGreen = 0x00FF00;
-  static const uint32_t kBlue = 0x0000FF;
-  static const uint32_t kYellow = 0xB58900;
-  static const uint32_t kOrange = 0xCB4B16;
-  static const uint32_t kRed1 = 0xDC322F;
-  static const uint32_t kMagenta = 0xD33682;
-  static const uint32_t kViolet = 0x6C71C4;
-  static const uint32_t kBlue1 = 0x268BD2;
-  static const uint32_t kCyan = 0x2AA198;
-  static const uint32_t kGreen1 = 0x859900;
-  static const uint32_t knvGreen = 0x76B900;
+  static const uint32_t kNvGreen = 0x76B900;
+  static const uint32_t kNavy = 0x22577E;
+  static const uint32_t kTeal = 0x95D1CC;
   static const uint32_t kPantyPink = 0xBD8BC3;
 
 
-  TimeRange(std::string name, const uint32_t rgb = kPantyPink) {  // NOLINT
+  explicit TimeRange(const std::string& name, const uint32_t rgb = kPantyPink) {
     nvtxEventAttributes_t att = {};
     att.version = NVTX_VERSION;
     att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;

--- a/src/dali_model_instance.cc
+++ b/src/dali_model_instance.cc
@@ -109,19 +109,33 @@ std::vector<TritonResponse> DaliModelInstance::CreateResponses(
   return responses;
 }
 
+
 ProcessingMeta DaliModelInstance::ProcessRequests(const std::vector<TritonRequest>& requests,
                                                   const std::vector<TritonResponse>& responses) {
   ProcessingMeta ret{};
+
+  TimeRange tr_gi("[DALI BE] GenerateInputs", 0x488FB1);
   auto inputs_info = GenerateInputs(requests);
+  tr_gi.stop();
+
+  TimeRange tr_run("[DALI BE] Run processing", 0x488FB1);
   start_timer_ns(ret.compute_interval);
   auto outputs_info = dali_executor_->Run(inputs_info.inputs);
   end_timer_ns(ret.compute_interval);
   for (auto& bs : inputs_info.reqs_batch_sizes) {
     ret.total_batch_size += bs;
   }
+  tr_run.stop();
+
+  TimeRange tr_ao("[DALI BE] AllocateOutputs", 0x488FB1);
   auto dali_outputs =
       AllocateOutputs(requests, responses, inputs_info.reqs_batch_sizes, outputs_info);
+  tr_ao.stop();
+
+  TimeRange tr_copy("[DALI BE] Copy results", 0x488FB1);
   dali_executor_->PutOutputs(dali_outputs);
+  tr_copy.stop();
+
   return ret;
 }
 

--- a/src/dali_model_instance.cc
+++ b/src/dali_model_instance.cc
@@ -114,11 +114,11 @@ ProcessingMeta DaliModelInstance::ProcessRequests(const std::vector<TritonReques
                                                   const std::vector<TritonResponse>& responses) {
   ProcessingMeta ret{};
 
-  TimeRange tr_gi("[DALI BE] GenerateInputs", 0x488FB1);
+  TimeRange tr_gi("[DALI BE] GenerateInputs", TimeRange::kTeal);
   auto inputs_info = GenerateInputs(requests);
   tr_gi.stop();
 
-  TimeRange tr_run("[DALI BE] Run processing", 0x488FB1);
+  TimeRange tr_run("[DALI BE] Run processing", TimeRange::kTeal);
   start_timer_ns(ret.compute_interval);
   auto outputs_info = dali_executor_->Run(inputs_info.inputs);
   end_timer_ns(ret.compute_interval);
@@ -127,12 +127,12 @@ ProcessingMeta DaliModelInstance::ProcessRequests(const std::vector<TritonReques
   }
   tr_run.stop();
 
-  TimeRange tr_ao("[DALI BE] AllocateOutputs", 0x488FB1);
+  TimeRange tr_ao("[DALI BE] AllocateOutputs", TimeRange::kTeal);
   auto dali_outputs =
       AllocateOutputs(requests, responses, inputs_info.reqs_batch_sizes, outputs_info);
   tr_ao.stop();
 
-  TimeRange tr_copy("[DALI BE] Copy results", 0x488FB1);
+  TimeRange tr_copy("[DALI BE] Copy results", TimeRange::kTeal);
   dali_executor_->PutOutputs(dali_outputs);
   tr_copy.stop();
 


### PR DESCRIPTION
This PR adds NVTX markers for profiling DALI Backend with `nsys`. Also, creates a `DALI Backend` domain for the same usage.

Here's roughly, how it looks with the proposed markers:
![image](https://user-images.githubusercontent.com/7101064/160834617-21936d67-3fd7-4bee-946a-f3ec6ab095bf.png)


Signed-off-by: szalpal <mszolucha@nvidia.com>