### PR TITLE
Update test condition for perf_analyzer_example

### DIFF
--- a/qa/L0_perf_analyzer_example/test.sh
+++ b/qa/L0_perf_analyzer_example/test.sh
@@ -25,4 +25,4 @@
 
 perf_analyzer -m dali -i grpc -u $GRPC_ADDR -b 64 --input-data test_image --shape DALI_INPUT_0:"$(stat --printf='%s' test_image/DALI_INPUT_0)" -f results.txt
 # Test if the perf_analyzer output is in a proper format and the measured times are in a reasonable range.
-[[ "$(tail -n1 results.txt)" =~ ^1,[0-9]{1,}\.[0-9],([0-9]{1,},){10}[0-9]{1,}$ ]] && echo "Output Correct"
+[[ "$(tail -n1 results.txt)" =~ ^1,[0-9]{1,}?\.*[0-9],([0-9]{1,},){10}[0-9]{1,}$ ]] && echo "Output Correct"


### PR DESCRIPTION
The previous test condition didn't forsee a situation, when measured throughput value does not have fractional part, e.g.:
```bash
Throughput: 76.8 infer/sec   -> test passed: matched the [0-9]{1,}\.[0-9] pattern
Throughput: 128 infer/sec    -> test failed: didn't match the pattern 
```
This PR adds this option.

Signed-off-by: szalpal <mszolucha@nvidia.com>