### PR TITLE
Omit `unused-local-typedefs` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif ()  # TRITON_ENABLE_GPU
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-local-typedefs")
 
 if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")


### PR DESCRIPTION
Fixes the problem with warning propagated from `libcudacxx` to DALI and DALI Backend, which fails the build whenever `-Werror` has been turned on. Such situation might happen, since the parent project in CMake might do something along these lines:
```cmake
set(CMAKE_CXX_FLAGS "-Werror")
```
And this makes `-Werror` turned on, but by the parent project.

Signed-off-by: szalpal <mszolucha@nvidia.com>