### PR TITLE
Add options to choose downloaded DALI version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,12 @@ set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
     "Extra options for `pip download` call, that downloads DALI wheel.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
+if (${TRITON_DALI_SKIP_DOWNLOAD})
+    message(STATUS "Skipping DALI download.")
+else ()
     message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
     message(STATUS "Downloading DALI from: ${DALI_EXTRA_INDEX_URL}")
+    message(STATUS "Downloading DALI with extra options: ${DALI_DOWNLOAD_EXTRA_OPTIONS}")
 endif ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,24 +51,28 @@ set(DALI_DOWNLOAD_VERSION "" CACHE STRING
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_DOWNLOAD_NIGHTLY OFF CACHE STRING
-    "Set to ON if the DALI nightly version should be downloaded.
+set(DALI_DOWNLOAD_TYPE "release" CACHE STRING
+    "Type of the DALI version to download. Accepted values are: release, weekly, nightly.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD in ON")
 
-if (NOT ${DALI_DOWNLOAD_NIGHTLY})
-  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
-      "URL of the Index, from which DALI will be downloaded by the build system.
-      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-else()
+if (${DALI_DOWNLOAD_TYPE} STREQUAL "nightly")
   set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist/nightly" CACHE STRING
       "URL of the Index, from which DALI will be downloaded by the build system.
       Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-endif()
+elseif (${DALI_DOWNLOAD_TYPE} STREQUAL "weekly")
+  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist/weekly" CACHE STRING
+      "URL of the Index, from which DALI will be downloaded by the build system.
+      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+else ()
+  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+      "URL of the Index, from which DALI will be downloaded by the build system.
+      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+endif ()
 
 set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
-        "Extra options for `pip download` call, that downloads DALI wheel.
-         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
-)
+    "Extra options for `pip download` call, that downloads DALI wheel.
+    Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
     message(STATUS "Building with DALI version (latest if empty): ${DALI_DOWNLOAD_VERSION}")
     message(STATUS "Downloading DALI from: ${DALI_DOWNLOAD_EXTRA_INDEX_URL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(DALI_VERSION "" CACHE STRING
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
     "URL of the Index, from which DALI will be downloaded by the build system.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
@@ -61,7 +61,7 @@ set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
     message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
-    message(STATUS "Downloading DALI from: ${DALI_DOWNLOAD_EXTRA_INDEX_URL}")
+    message(STATUS "Downloading DALI from: ${DALI_EXTRA_INDEX_URL}")
 endif ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,22 +46,32 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
-set(DALI_VERSION "" CACHE STRING
-        "DALI version that should be downloaded by the build system.
-         By default the latest available DALI version will be downloaded.
-         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
-)
-set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
-        "URL of the Index, from which DALI will be downloaded by the build system.
-         Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
-)
+set(DALI_DOWNLOAD_VERSION "" CACHE STRING
+    "DALI version that should be downloaded by the build system.
+    By default the latest available DALI version will be downloaded.
+    Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+
+set(DALI_DOWNLOAD_NIGHTLY OFF CACHE STRING
+    "Set to ON if the DALI nightly version should be downloaded.
+    Ignored, when TRITON_DALI_SKIP_DOWNLOAD in ON")
+
+if (NOT ${DALI_DOWNLOAD_NIGHTLY})
+  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+      "URL of the Index, from which DALI will be downloaded by the build system.
+      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+else()
+  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist/nightly" CACHE STRING
+      "URL of the Index, from which DALI will be downloaded by the build system.
+      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+endif()
+
 set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
         "Extra options for `pip download` call, that downloads DALI wheel.
          Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON."
 )
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-    message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
-    message(STATUS "Downloading DALI from: ${DALI_EXTRA_INDEX_URL}")
+    message(STATUS "Building with DALI version (latest if empty): ${DALI_DOWNLOAD_VERSION}")
+    message(STATUS "Downloading DALI from: ${DALI_DOWNLOAD_EXTRA_INDEX_URL}")
 endif ()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,35 +46,21 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
-set(DALI_DOWNLOAD_VERSION "" CACHE STRING
+set(DALI_VERSION "" CACHE STRING
     "DALI version that should be downloaded by the build system.
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_DOWNLOAD_TYPE "release" CACHE STRING
-    "Type of the DALI version to download. Accepted values are: release, weekly, nightly.
-    Ignored, when TRITON_DALI_SKIP_DOWNLOAD in ON")
-
-if (${DALI_DOWNLOAD_TYPE} STREQUAL "nightly")
-  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist/nightly" CACHE STRING
-      "URL of the Index, from which DALI will be downloaded by the build system.
-      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-elseif (${DALI_DOWNLOAD_TYPE} STREQUAL "weekly")
-  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist/weekly" CACHE STRING
-      "URL of the Index, from which DALI will be downloaded by the build system.
-      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-else ()
-  set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
-      "URL of the Index, from which DALI will be downloaded by the build system.
-      Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-endif ()
+set(DALI_DOWNLOAD_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+    "URL of the Index, from which DALI will be downloaded by the build system.
+    Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
 set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
     "Extra options for `pip download` call, that downloads DALI wheel.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-    message(STATUS "Building with DALI version (latest if empty): ${DALI_DOWNLOAD_VERSION}")
+    message(STATUS "Building with DALI version (latest if empty): ${DALI_VERSION}")
     message(STATUS "Downloading DALI from: ${DALI_DOWNLOAD_EXTRA_INDEX_URL}")
 endif ()
 
@@ -117,6 +103,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-f
 if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()
+
+set(DALI_DOWNLOAD_PKG_NAME "nvidia-dali-cuda${CUDAToolkit_VERSION_MAJOR}0" CACHE STRING
+    "DALI pip package name to download.
+    Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
 add_subdirectory(src)
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -92,7 +92,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
-      -D DALI_DOWNLOAD_EXTRA_OPTIONS=${DALI_DOWNLOAD_EXTRA_OPTIONS}                   \
+      -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -65,20 +65,27 @@ RUN CMAKE_VERSION=3.17 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /cmake-${CMAKE_BUILD}
 
-RUN pip install --force-reinstall --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly nvidia-dali-nightly-cuda110
-
 WORKDIR /dali
 
 COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
 
-RUN mkdir build_in_ci && cd build_in_ci && \
-    cmake                                                         \
-      -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                   \
-      -D CMAKE_BUILD_TYPE=Debug                                   \
-      -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION} \
-      .. &&                                                       \
+ARG DALI_DOWNLOAD_NIGHTLY=OFF
+ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
+ARG DALI_DOWNLOAD_VERSION
+
+RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                                 \
+    cmake                                                                             \
+      -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
+      -D CMAKE_BUILD_TYPE=Debug                                                       \
+      -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
+      -D DALI_DOWNLOAD_NIGHTLY=${DALI_DOWNLOAD_NIGHTLY}                               \
+      `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
+         echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
+      fi`                                                                             \
+      -D DALI_DOWNLOAD_VERSION=${DALI_DOWNLOAD_VERSION}                               \
+      .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 
 WORKDIR /opt/tritonserver

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -85,12 +85,6 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Debug                                                       \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      ${DALI_DOWNLOAD_PKG_NAME:+                                                      \
-        -D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}}                          \
-      ${DALI_DOWNLOAD_EXTRA_INDEX_URL:+                                               \
-        -D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}}                     \
-      -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
-      -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -89,7 +89,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
         echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
       fi`                                                                             \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
-         echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
+         echo -n "-D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}";          \
       fi`                                                                             \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -74,7 +74,7 @@ ARG DALI_DOWNLOAD_EXTRA_OPTIONS
 
 RUN pip install --force-reinstall \
     ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} \
-    ${DALI_DOWNLOAD_PKG_NAME}`if [ -n "${DALI_DOWNLOAD_VERSION}" ]; then echo "==${DALI_DOWNLOAD_VERSION}"; fi`
+    ${DALI_DOWNLOAD_PKG_NAME}${DALI_DOWNLOAD_VERSION:+==${DALI_DOWNLOAD_VERSION}}
 
 COPY . .
 
@@ -85,12 +85,10 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Debug                                                       \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      `if [ -n "${DALI_DOWNLOAD_PKG_NAME}" ]; then                                    \
-        echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
-      fi`                                                                             \
-      `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
-         echo -n "-D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}";          \
-      fi`                                                                             \
+      ${DALI_DOWNLOAD_PKG_NAME:+                                                      \
+        -D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}}                          \
+      ${DALI_DOWNLOAD_EXTRA_INDEX_URL:+                                               \
+        -D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}}                     \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -67,24 +67,31 @@ RUN CMAKE_VERSION=3.17 && \
 
 WORKDIR /dali
 
+ARG DALI_DOWNLOAD_EXTRA_INDEX_URL=https://developer.download.nvidia.com/compute/redist/nightly
+ARG DALI_DOWNLOAD_PKG_NAME=nvidia-dali-nightly-cuda110
+ARG DALI_DOWNLOAD_VERSION
+
+RUN pip install --force-reinstall \
+    --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} \
+    ${DALI_DOWNLOAD_PKG_NAME}`if [ -n "${DALI_DOWNLOAD_VERSION}" ]; then echo "==${DALI_DOWNLOAD_VERSION}"; fi`
+
 COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
-
-ARG DALI_DOWNLOAD_TYPE="release"
-ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
-ARG DALI_DOWNLOAD_VERSION
 
 RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                                 \
     cmake                                                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Debug                                                       \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      -D DALI_DOWNLOAD_TYPE=${DALI_DOWNLOAD_TYPE}                                     \
+      `if [ -n "${DALI_DOWNLOAD_PKG_NAME}" ]; then                                    \
+        echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
+      fi`                                                                             \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
-      -D DALI_DOWNLOAD_VERSION=${DALI_DOWNLOAD_VERSION}                               \
+      -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
+      -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -70,9 +70,10 @@ WORKDIR /dali
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL=https://developer.download.nvidia.com/compute/redist/nightly
 ARG DALI_DOWNLOAD_PKG_NAME=nvidia-dali-nightly-cuda110
 ARG DALI_DOWNLOAD_VERSION
+ARG DALI_DOWNLOAD_EXTRA_OPTIONS
 
 RUN pip install --force-reinstall \
-    --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} \
+    ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} \
     ${DALI_DOWNLOAD_PKG_NAME}`if [ -n "${DALI_DOWNLOAD_VERSION}" ]; then echo "==${DALI_DOWNLOAD_VERSION}"; fi`
 
 COPY . .
@@ -91,6 +92,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
+      -D DALI_DOWNLOAD_EXTRA_OPTIONS=${DALI_DOWNLOAD_EXTRA_OPTIONS}                   \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -71,7 +71,7 @@ COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
 
-ARG DALI_DOWNLOAD_NIGHTLY=OFF
+ARG DALI_DOWNLOAD_TYPE="release"
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
 ARG DALI_DOWNLOAD_VERSION
 
@@ -80,7 +80,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Debug                                                       \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      -D DALI_DOWNLOAD_NIGHTLY=${DALI_DOWNLOAD_NIGHTLY}                               \
+      -D DALI_DOWNLOAD_TYPE=${DALI_DOWNLOAD_TYPE}                                     \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -67,24 +67,26 @@ RUN CMAKE_VERSION=3.17 && \
 
 WORKDIR /dali
 
+ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
+ARG DALI_DOWNLOAD_PKG_NAME
+ARG DALI_DOWNLOAD_VERSION
+
 COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
-
-ARG DALI_DOWNLOAD_TYPE="release"
-ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
-ARG DALI_DOWNLOAD_VERSION
 
 RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                                 \
     cmake                                                                             \
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Release                                                     \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      -D DALI_DOWNLOAD_TYPE=${DALI_DOWNLOAD_TYPE}                                     \
+      `if [ -n "${DALI_DOWNLOAD_PKG_NAME}" ]; then                                    \
+        echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
+      fi`                                                                             \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
-      -D DALI_DOWNLOAD_VERSION=${DALI_DOWNLOAD_VERSION}                               \
+      -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                               \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -71,7 +71,7 @@ COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
 
-ARG DALI_DOWNLOAD_NIGHTLY=OFF
+ARG DALI_DOWNLOAD_TYPE="release"
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
 ARG DALI_DOWNLOAD_VERSION
 
@@ -80,7 +80,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Release                                                     \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      -D DALI_DOWNLOAD_NIGHTLY=${DALI_DOWNLOAD_NIGHTLY}                               \
+      -D DALI_DOWNLOAD_TYPE=${DALI_DOWNLOAD_TYPE}                                     \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -88,7 +88,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
-      -D DALI_DOWNLOAD_EXTRA_OPTIONS=${DALI_DOWNLOAD_EXTRA_OPTIONS}                   \
+      -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -65,21 +65,27 @@ RUN CMAKE_VERSION=3.17 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /cmake-${CMAKE_BUILD}
 
-RUN pip install --force-reinstall --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly nvidia-dali-nightly-cuda110
-
 WORKDIR /dali
 
 COPY . .
 
 ARG TRITON_BACKEND_API_VERSION="r21.05"
 
-RUN mkdir build_in_ci && cd build_in_ci && \
-    cmake                                                         \
-      -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                   \
-      -D CMAKE_BUILD_TYPE=Release                                 \
-      -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION} \
-      -D WERROR=ON                                                \
-      .. &&                                                       \
+ARG DALI_DOWNLOAD_NIGHTLY=OFF
+ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
+ARG DALI_DOWNLOAD_VERSION
+
+RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                                 \
+    cmake                                                                             \
+      -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
+      -D CMAKE_BUILD_TYPE=Release                                                     \
+      -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
+      -D DALI_DOWNLOAD_NIGHTLY=${DALI_DOWNLOAD_NIGHTLY}                               \
+      `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
+         echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
+      fi`                                                                             \
+      -D DALI_DOWNLOAD_VERSION=${DALI_DOWNLOAD_VERSION}                               \
+      .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 
 WORKDIR /opt/tritonserver

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -85,7 +85,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
         echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
       fi`                                                                             \
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
-         echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
+         echo -n "-D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}";          \
       fi`                                                                             \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -70,6 +70,7 @@ WORKDIR /dali
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
 ARG DALI_DOWNLOAD_PKG_NAME
 ARG DALI_DOWNLOAD_VERSION
+ARG DALI_DOWNLOAD_EXTRA_OPTIONS
 
 COPY . .
 
@@ -86,7 +87,8 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
          echo -n "-D DALI_DOWNLOAD_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}"; \
       fi`                                                                             \
-      -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                               \
+      -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
+      -D DALI_DOWNLOAD_EXTRA_OPTIONS=${DALI_DOWNLOAD_EXTRA_OPTIONS}                   \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -81,12 +81,10 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D CMAKE_INSTALL_PREFIX=/opt/tritonserver                                       \
       -D CMAKE_BUILD_TYPE=Release                                                     \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION}                     \
-      `if [ -n "${DALI_DOWNLOAD_PKG_NAME}" ]; then                                    \
-        echo -n "-D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}";                \
-      fi`                                                                             \
-      `if [ -n "${DALI_DOWNLOAD_EXTRA_INDEX_URL}" ]; then                             \
-         echo -n "-D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}";          \
-      fi`                                                                             \
+      ${DALI_DOWNLOAD_PKG_NAME:+                                                      \
+        -D DALI_DOWNLOAD_PKG_NAME=${DALI_DOWNLOAD_PKG_NAME}}                          \
+      ${DALI_DOWNLOAD_EXTRA_INDEX_URL:+                                               \
+        -D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}}                     \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       .. &&                                                                           \

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -28,11 +28,13 @@ set(
 
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
+separate_arguments(EXTRA_DOWNLOAD_ARGS UNIX_COMMAND ${DALI_DOWNLOAD_EXTRA_OPTIONS})
+
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} 
-          --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} 
+        pip download ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
+          -d ${CMAKE_CURRENT_BINARY_DIR}
           ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -28,11 +28,17 @@ set(
 
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
+if (${DALI_DOWNLOAD_NIGHTLY})
+    set(DALI_DOWNLOAD_PACKAGE_NAME nvidia-dali-nightly-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+else()
+    set(DALI_DOWNLOAD_PACKAGE_NAME nvidia-dali-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+endif()
+
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
-        nvidia-dali-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
+        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL}
+        ${DALI_DOWNLOAD_PACKAGE_NAME}
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
     COMMAND touch dali_whl  # So that this command won't be re-run every time
@@ -74,4 +80,3 @@ install(
         ${DALI_LIB_DIR}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali
 )
-

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -28,17 +28,30 @@ set(
 
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
-if (${DALI_DOWNLOAD_NIGHTLY})
-    set(DALI_DOWNLOAD_PACKAGE_NAME nvidia-dali-nightly-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+string(CONCAT DALI_DOWNLOAD_CUDA_VERSION ${CUDAToolkit_VERSION_MAJOR} ${CUDAToolkit_VERSION_MINOR})
+if (${CUDAToolkit_VERSION_MAJOR} GREATER_EQUAL 11)
+    set(DALI_DOWNLOAD_CUDA_VERSION_MINOR 0)
 else()
-    set(DALI_DOWNLOAD_PACKAGE_NAME nvidia-dali-cuda110$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+    set(DALI_DOWNLOAD_CUDA_VERSION_MINOR ${CUDAToolkit_VERSION_MINOR})
 endif()
+string(CONCAT DALI_DOWNLOAD_CUDA_VERSION ${CUDAToolkit_VERSION_MAJOR} ${DALI_DOWNLOAD_CUDA_VERSION_MINOR})
+
+if (${DALI_DOWNLOAD_TYPE} STREQUAL "nightly")
+    set(DALI_DOWNLOAD_PACKAGE_NAME 
+        nvidia-dali-nightly-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+elseif (${DALI_DOWNLOAD_TYPE} STREQUAL "weekly")
+    set(DALI_DOWNLOAD_PACKAGE_NAME 
+        nvidia-dali-weekly-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+else ()
+    set(DALI_DOWNLOAD_PACKAGE_NAME 
+        nvidia-dali-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
+endif ()
 
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL}
-        ${DALI_DOWNLOAD_PACKAGE_NAME}
+        pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} 
+          --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} ${DALI_DOWNLOAD_PACKAGE_NAME}
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
     COMMAND touch dali_whl  # So that this command won't be re-run every time

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -28,30 +28,12 @@ set(
 
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
-string(CONCAT DALI_DOWNLOAD_CUDA_VERSION ${CUDAToolkit_VERSION_MAJOR} ${CUDAToolkit_VERSION_MINOR})
-if (${CUDAToolkit_VERSION_MAJOR} GREATER_EQUAL 11)
-    set(DALI_DOWNLOAD_CUDA_VERSION_MINOR 0)
-else()
-    set(DALI_DOWNLOAD_CUDA_VERSION_MINOR ${CUDAToolkit_VERSION_MINOR})
-endif()
-string(CONCAT DALI_DOWNLOAD_CUDA_VERSION ${CUDAToolkit_VERSION_MAJOR} ${DALI_DOWNLOAD_CUDA_VERSION_MINOR})
-
-if (${DALI_DOWNLOAD_TYPE} STREQUAL "nightly")
-    set(DALI_DOWNLOAD_PACKAGE_NAME 
-        nvidia-dali-nightly-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
-elseif (${DALI_DOWNLOAD_TYPE} STREQUAL "weekly")
-    set(DALI_DOWNLOAD_PACKAGE_NAME 
-        nvidia-dali-weekly-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
-else ()
-    set(DALI_DOWNLOAD_PACKAGE_NAME 
-        nvidia-dali-cuda${DALI_DOWNLOAD_CUDA_VERSION}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>)
-endif ()
-
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
         pip download -d ${CMAKE_CURRENT_BINARY_DIR} ${DALI_DOWNLOAD_EXTRA_OPTIONS} 
-          --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} ${DALI_DOWNLOAD_PACKAGE_NAME}
+          --extra-index-url ${DALI_DOWNLOAD_EXTRA_INDEX_URL} 
+          ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND
         unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
     COMMAND touch dali_whl  # So that this command won't be re-run every time


### PR DESCRIPTION
This PR exposes in dcokerfiles the options to choose DALI version downloaded during the backend build.

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>