### PR TITLE
Implment auto-config tools

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION
+# Copyright (c) 2020-2022 NVIDIA CORPORATION
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -88,5 +88,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                                                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
+
+ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:/opt/tritonserver/backends/dali/dali:${LD_LIBRARY_PATH}
 
 WORKDIR /opt/tritonserver

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION
+# Copyright (c) 2020-2022 NVIDIA CORPORATION
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -89,5 +89,7 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
+
+ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:/opt/tritonserver/backends/dali/dali:${LD_LIBRARY_PATH}
 
 WORKDIR /opt/tritonserver

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -24,25 +24,53 @@ configure_file(libtriton_dali.ldscript libtriton_dali.ldscript COPYONLY)
 add_subdirectory(dali_executor)
 
 add_library(
+        triton-dali-backend-utils STATIC
+        utils/triton.cc
+        config_tools/config_tools.cc
+)
+
+target_include_directories(
+        triton-dali-backend-utils PUBLIC
+        ${tritondalibackend_SOURCE_DIR}
+        ${DALI_INCLUDE_DIR}
+)
+
+target_link_libraries(
+        triton-dali-backend-utils PUBLIC
+        triton-core-serverstub
+        triton-backend-utils
+)
+
+set_target_properties(
+        triton-dali-backend-utils
+        PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            SKIP_BUILD_RPATH TRUE
+            BUILD_WITH_INSTALL_RPATH TRUE
+            INSTALL_RPATH_USE_LINK_PATH FALSE
+            INSTALL_RPATH ""
+            CXX_STANDARD 17
+)
+
+
+add_library(
         triton-dali-backend SHARED
         dali_backend.cc
         dali_model_instance.cc
         dali_model.cc
-        utils/triton.cc
 )
 
 add_library(
         TritonDaliBackend::triton-dali-backend ALIAS triton-dali-backend
 )
 
+
 target_include_directories(
         triton-dali-backend
         PRIVATE
         ${tritondalibackend_SOURCE_DIR}
-        ${DALI_INCLUDE_DIR}
 )
 
-target_compile_features(triton-dali-backend PRIVATE cxx_std_14)
 target_compile_options(
         triton-dali-backend PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
@@ -52,9 +80,8 @@ target_compile_options(
 target_link_libraries(
         triton-dali-backend
         PRIVATE
-        triton-core-serverstub  # from repo-core
-        triton-backend-utils    # from repo-backend
         dali_executor
+        triton-dali-backend-utils
 )
 
 set_target_properties(
@@ -68,6 +95,7 @@ set_target_properties(
             BUILD_WITH_INSTALL_RPATH TRUE
             INSTALL_RPATH_USE_LINK_PATH FALSE
             INSTALL_RPATH "$\{ORIGIN\}/dali"
+            CXX_STANDARD 17
 )
 
 set(
@@ -76,7 +104,26 @@ set(
         dali_executor/executor.test.cc
         dali_executor/io_buffer.test.cc
         utils/utils.test.cc
+        config_tools/config_tools.test.cc
 )
 
 add_executable(unittests ${DALI_BACKEND_TEST_SRCS})
-target_link_libraries(unittests Catch2::Catch2 dali_executor ${CMAKE_DL_LIBS})
+target_link_libraries(
+        unittests
+        PRIVATE
+        Catch2::Catch2
+        dali_executor
+        triton-dali-backend-utils
+        ${CMAKE_DL_LIBS}
+)
+
+set_target_properties(
+        unittests
+        PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            SKIP_BUILD_RPATH TRUE
+            BUILD_WITH_INSTALL_RPATH TRUE
+            INSTALL_RPATH_USE_LINK_PATH FALSE
+            INSTALL_RPATH ""
+            CXX_STANDARD 17
+)

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -1,0 +1,293 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "src/config_tools/config_tools.h"
+
+namespace triton { namespace backend { namespace dali {
+
+
+/**
+ * @brief convert DALI data type to type string used in Triton model config
+ */
+std::string to_triton_config(dali_data_type_t type) {
+  switch (type) {
+    case DALI_UINT8   :
+      return "TYPE_UINT8";
+    case DALI_UINT16  :
+      return "TYPE_UINT16";
+    case DALI_UINT32  :
+      return "TYPE_UINT32";
+    case DALI_UINT64  :
+      return "TYPE_UINT64";
+    case DALI_INT8    :
+      return "TYPE_INT8";
+    case DALI_INT16   :
+      return "TYPE_INT16";
+    case DALI_INT32   :
+      return "TYPE_INT32";
+    case DALI_INT64   :
+      return "TYPE_INT64";
+    case DALI_FLOAT16 :
+      return "TYPE_FP16";
+    case DALI_FLOAT   :
+      return "TYPE_FP32";
+    case DALI_FLOAT64 :
+      return "TYPE_FP64";
+    case DALI_BOOL    :
+      return "TYPE_BOOL";
+    default:
+      return "TYPE_INVALID";
+  }
+}
+
+void SetShapeArray(TritonJson::Value &array, const std::vector<int64_t> &dims) {
+  TRITON_CALL(array.AssertType(TritonJson::ValueType::ARRAY));
+  ENFORCE(array.ArraySize() <= dims.size(), "SetShapeArray expects the initial array size to be "
+                                            "smaller or equal the number of dimensions.");
+  size_t i = 0;
+  const auto arr_size = array.ArraySize();
+  for (; i < arr_size; ++i) {
+    TritonJson::Value elem;
+    array.At(i, &elem);
+    elem.SetInt(dims[i]);
+  }
+  for (; i < dims.size(); ++i) {
+    array.AppendInt(dims[i]);
+  }
+}
+
+
+std::optional<size_t> FindObjectByName(TritonJson::Value &array, const std::string &name,
+                                       TritonJson::Value *ret) {
+  TritonJson::Value obj;
+  size_t len = array.ArraySize();
+  for (size_t i = 0; i < len; ++i) {
+    array.IndexAsObject(i, &obj);
+    std::string found_name;
+    auto err = obj.MemberAsString("name", &found_name);
+    if (!err && found_name == name) {
+      ret->Release();
+      array.IndexAsObject(i, ret);
+      return {i};
+    }
+  }
+  return {};
+}
+
+
+std::vector<int64_t> ReadShape(TritonJson::Value &dims_array) {
+  TRITON_CALL(dims_array.AssertType(TritonJson::ValueType::ARRAY));
+  size_t len = dims_array.ArraySize();
+  std::vector<int64_t> result(len);
+  for (size_t i = 0; i < len; ++i) {
+    TRITON_CALL(dims_array.IndexAsInt(i, &result[i]));
+  }
+  return result;
+}
+
+std::vector<int64_t> MatchShapes(const std::string &name,
+                                 const std::vector<int64_t> &config_shape,
+                                 const std::vector<int64_t> &pipeline_shape) {
+  if (config_shape.size() != pipeline_shape.size()) {
+    throw TritonError::InvalidArg(make_string("Mismatch in number of dimensions for ", name, "\n"
+                                  "Number of dimensions defined in config: ", config_shape.size(),
+                                  "\nNumber of dimensions defined in pipeline: ",
+                                  pipeline_shape.size()));
+  }
+  std::vector<int64_t> result(config_shape.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    if (config_shape[i] != pipeline_shape[i]) {
+      if (config_shape[i] == -1 || pipeline_shape[i] == -1) {
+        result[i] = std::max(config_shape[i], pipeline_shape[i]);
+      } else {
+        throw TritonError::InvalidArg(
+          make_string("Mismath in dims for ", name, "\nDims defined in config: ",
+                      vec_to_string(config_shape), "\nDims defined in pipeline: ",
+                      vec_to_string(pipeline_shape)));
+      }
+    } else {
+      result[i] = config_shape[i];
+    }
+  }
+  return result;
+}
+
+template <bool allow_missing>
+std::string ProcessDtypeConfig(TritonJson::Value &io_object, const std::string &name,
+                              dali_data_type_t dtype) {
+  TritonJson::Value dtype_obj(TritonJson::ValueType::OBJECT);
+  if (io_object.Find("data_type", &dtype_obj)) {
+    std::string found_dtype;
+    TRITON_CALL(dtype_obj.AsString(&found_dtype));
+    if (found_dtype != "TYPE_INVALID") {
+      if (dtype != DALI_NO_TYPE) {
+        if (found_dtype != to_triton_config(dtype)) {
+          throw TritonError::InvalidArg(make_string(
+            "Mismatch of data_type config for \"", name, "\". \n"
+            "Data type defined in config: ", found_dtype, "\n"
+            "Data type defined in pipeline: ", to_triton_config(dtype)));
+        }
+      }
+      return found_dtype;
+    }
+  }
+  if (!allow_missing) {
+    throw TritonError::InvalidArg(make_string("Missing data_type config for \"", name, "\""));
+  }
+  return to_triton_config(dtype);
+}
+
+
+std::string AutofillDtypeConfig(TritonJson::Value &io_object, const std::string &name,
+                                dali_data_type_t dtype) {
+  return ProcessDtypeConfig<true>(io_object, name, dtype);
+}
+
+void ValidateDtypeConfig(TritonJson::Value &io_object, const std::string &name,
+                        dali_data_type_t dtype) {
+  ProcessDtypeConfig<false>(io_object, name, dtype);
+}
+
+
+template <bool allow_missing>
+void ProcessShapeConfig(TritonJson::Value &io_object, const std::string &name,
+                        const std::optional<std::vector<int64_t>> &shape, 
+                        TritonJson::Value &resulting_dims) {
+  TritonJson::Value dims_obj;
+  if (io_object.MemberAsArray("dims", &dims_obj) == TRITONJSON_STATUSSUCCESS) {
+    auto config_shape = ReadShape(dims_obj);
+    if (shape) {
+      auto resulting_shape = MatchShapes(name, config_shape, *shape);
+      SetShapeArray(resulting_dims, resulting_shape);
+    } else {
+      SetShapeArray(resulting_dims, config_shape);
+    }
+  } else if (allow_missing) {
+    if (shape) {
+      SetShapeArray(resulting_dims, *shape);
+    } else {
+      SetShapeArray(resulting_dims, {});
+    }
+  } else {
+    throw TritonError::InvalidArg(make_string("Missing dims config for \"", name, "\""));
+  }
+}
+
+
+void AutofillShapeConfig(TritonJson::Value &io_object, const std::string &name,
+                         const std::optional<std::vector<int64_t>> &shape, 
+                         TritonJson::Value &resulting_dims) {
+  ProcessShapeConfig<true>(io_object, name, shape, resulting_dims);
+}
+
+
+void ValidateShapeConfig(TritonJson::Value &io_object, const std::string &name,
+                         const std::optional<std::vector<int64_t>> &shape) {
+  TritonJson::Value dummy(TritonJson::ValueType::ARRAY);
+  ProcessShapeConfig<false>(io_object, name, shape, dummy);
+}
+
+
+void AutofillIOConfig(TritonJson::Value &io_object, const IOConfig &io_config,
+                      TritonJson::Value &new_io_object) {
+  TRITON_CALL(io_object.AssertType(common::TritonJson::ValueType::OBJECT));
+  TRITON_CALL(new_io_object.AssertType(common::TritonJson::ValueType::OBJECT));
+
+  new_io_object.AddString("name", io_config.name);
+
+  std::string new_data_type = AutofillDtypeConfig(io_object, io_config.name, io_config.dtype);
+  new_io_object.AddString("data_type", new_data_type);
+
+  TritonJson::Value new_dims;
+  new_io_object.Add("dims", TritonJson::Value(new_io_object, TritonJson::ValueType::ARRAY));
+  new_io_object.MemberAsArray("dims", &new_dims);
+  AutofillShapeConfig(io_object, io_config.name, io_config.shape, new_dims);
+}
+
+
+void ValidateIOConfig(TritonJson::Value &io_object, const IOConfig &io_config) {
+  TRITON_CALL(io_object.AssertType(common::TritonJson::ValueType::OBJECT));
+  ValidateDtypeConfig(io_object, io_config.name, io_config.dtype);
+  ValidateShapeConfig(io_object, io_config.name, io_config.shape);
+}
+
+
+template <bool input>
+void AutofillIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_configs,
+                       TritonJson::Value &new_ios) {
+  TRITON_CALL(ios.AssertType(common::TritonJson::ValueType::ARRAY));
+  TRITON_CALL(new_ios.AssertType(common::TritonJson::ValueType::ARRAY));
+
+  std::vector<TritonJson::Value> new_io_objs(io_configs.size());
+  auto end_ind = ios.ArraySize();
+  for (const auto &io_config: io_configs) {
+    TritonJson::Value io_object(TritonJson::ValueType::OBJECT);
+    auto ind = FindObjectByName(ios, io_config.name, &io_object);
+    size_t io_index;
+    if (ind) {
+      io_index = *ind;
+    } else {
+      io_index = end_ind++;
+    }
+    new_io_objs[io_index] = TritonJson::Value(new_ios, TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_object, io_config, new_io_objs[io_index]);
+
+    if (input) {
+      bool ragged_batches;
+      if (io_object.MemberAsBool("allow_ragged_batches", &ragged_batches) 
+            == TRITONJSON_STATUSSUCCESS) {
+        new_io_objs[io_index].AddBool("allow_ragged_batches", ragged_batches);
+      } else {
+        new_io_objs[io_index].AddBool("allow_ragged_batches", true);
+      }
+    }
+  }
+
+  for (auto &new_io : new_io_objs) {
+    new_ios.Append(std::move(new_io));
+  }
+}
+
+
+void AutofillInputsConfig(TritonJson::Value &inputs, const std::vector<IOConfig> &in_configs,
+                          TritonJson::Value &new_ios) {
+  AutofillIOsConfig<true>(inputs, in_configs, new_ios);
+}
+
+
+void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfig> &out_configs,
+                           TritonJson::Value &new_ios) {
+  AutofillIOsConfig<false>(outputs, out_configs, new_ios);
+}
+
+void ValidateIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_configs) {
+  TRITON_CALL(ios.AssertType(common::TritonJson::ValueType::ARRAY));
+  for (const auto &io_config: io_configs) {
+    TritonJson::Value io_object(TritonJson::ValueType::OBJECT);
+    auto ind = FindObjectByName(ios, io_config.name, &io_object);
+    if (!ind) {
+      throw TritonError::InvalidArg(make_string("Missing config for \"", io_config.name, "\""));
+    }
+    ValidateIOConfig(io_object, io_config);
+  }
+}
+}}}  // namespace triton::backend::dali

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -1,0 +1,157 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef DALI_BACKEND_CONFIG_TOOLS_CONFIG_TOOLS_H_
+#define DALI_BACKEND_CONFIG_TOOLS_CONFIG_TOOLS_H_
+
+#include <optional>
+
+#include "src/utils/triton.h"
+#include "src/utils/utils.h"
+#include "triton/backend/backend_common.h"
+
+namespace triton { namespace backend { namespace dali {
+
+using triton::common::TritonJson;
+
+struct IOConfig {
+  std::string name;
+  dali_data_type_t dtype;
+  std::optional<std::vector<int64_t>> shape;
+
+  explicit IOConfig(const std::string &name, 
+                    dali_data_type_t dtype = DALI_NO_TYPE,
+                    std::optional<std::vector<int64_t>> shape = {})
+    : name(name)
+    , dtype(dtype)
+    , shape(shape) {}
+};
+
+/**
+ * @brief Convert DALI data type to type string used in Triton model config
+ */
+std::string to_triton_config(dali_data_type_t type);
+
+
+/**
+ * @brief Fill TritonJson array with values from dims.
+ * Initial size of array must be smaller or equal dims.size()
+ */
+void SetShapeArray(TritonJson::Value &array, const std::vector<int64_t> &dims);
+
+
+/**
+ * @brief Find object in array that has a name field equal to given string.
+ *  If found, the object is assigned to *ret and the index in array is returned.
+ *  The previous value of *ret is released.
+ *  If not found, *ret is not modified and an empty optional is returned.
+ */
+std::optional<size_t> FindObjectByName(TritonJson::Value &array, const std::string &name,
+                                       TritonJson::Value *ret);
+
+
+/**
+ * @brief Read an array of ints and return it as a vector.
+ */
+std::vector<int64_t> ReadShape(TritonJson::Value &dims_array);
+
+
+/**
+ * @brief Match shapes from config file and pipeline and return the result of matching.
+ * 
+ * e.g. shapes [-1, 2, -1] and [-1, -1, 3] will match to [-1, 2, 3]
+ * 
+ * Throws an error when shapes cannot be matched.
+ */
+std::vector<int64_t> MatchShapes(const std::string &name,
+                                 const std::vector<int64_t> &config_shape,
+                                 const std::vector<int64_t> &pipeline_shape);
+
+
+/**
+ * @brief Validates data_type field in IO object against provided value.
+ * Returns data type to be used for autofill.
+ */
+std::string AutofillDtypeConfig(TritonJson::Value &io_object, const std::string &name,
+                                dali_data_type_t dtype);
+
+
+/**
+ * @brief Validates data_type field in IO object against provided value.
+ */
+void ValidateDtypeConfig(TritonJson::Value &io_object, const std::string &name,
+                         dali_data_type_t dtype);
+
+
+/**
+ * @brief Validates dims field in IO object again provided value.
+ * Matches the shape from IO object with the provided shape
+ * and outputs the result of matching to resulting_dims.
+ */
+void AutofillShapeConfig(TritonJson::Value &io_object, const std::string &name,
+                         const std::optional<std::vector<int64_t>> &shape, 
+                         TritonJson::Value &resulting_dims);
+
+/**
+ * @brief Validates dims field in IO object again provided value.
+ */
+void ValidateShapeConfig(TritonJson::Value &io_object, const std::string &name,
+                         const std::optional<std::vector<int64_t>> &shape);
+
+/**
+ * @brief Validates IO object against provided config values 
+ * and outputs auto-configured IO object to new_io_object.
+ */
+void AutofillIOConfig(TritonJson::Value &io_object, const IOConfig &io_config,
+                      TritonJson::Value &new_io_object);
+
+
+/**
+ * @brief Validates IO object against provided config values.
+ */
+void ValidateIOConfig(TritonJson::Value &io_object, const IOConfig &io_config);
+
+
+/**
+ * @brief Validates inputs array against provided config values 
+ * auto outputs auto-configured array to new_ios.
+ */
+void AutofillInputsConfig(TritonJson::Value &inputs, const std::vector<IOConfig> &in_configs,
+                          TritonJson::Value &new_inputs);
+
+
+/**
+ * @brief Validates outputs array against provided config values 
+ * auto outputs auto-configured array to new_ios.
+ */
+void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfig> &out_configs,
+                           TritonJson::Value &new_outputs);
+
+
+/**
+ * @brief Validates inputs or outputs array against provided config values.
+ */
+void ValidateIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_configs);
+
+}}} // namespace triton::backend::dali
+
+#endif  // DALI_BACKEND_CONFIG_TOOLS_CONFIG_TOOLS_H_

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -1,0 +1,308 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#include <catch2/catch.hpp>
+
+#include "src/config_tools/config_tools.h"
+
+namespace triton { namespace backend { namespace dali { namespace test {
+
+using Catch::Matchers::Contains;
+
+static void CheckIOConfigEquals(TritonJson::Value &io, IOConfig io_config) {
+  CHECK(io.AssertType(TritonJson::ValueType::OBJECT) == TRITONJSON_STATUSSUCCESS);
+
+  std::string name;
+  CHECK(io.MemberAsString("name", &name) == TRITONJSON_STATUSSUCCESS);
+  CHECK(name == io_config.name);
+
+  TritonJson::Value dims(TritonJson::ValueType::ARRAY);
+  if (!io_config.shape) {
+    if (io.MemberAsArray("dims", &dims) == TRITONJSON_STATUSSUCCESS) {
+      CHECK(dims.ArraySize() == 0);
+    }
+  } else {
+    REQUIRE(io.MemberAsArray("dims", &dims) == TRITONJSON_STATUSSUCCESS);
+    CHECK(ReadShape(dims) == *io_config.shape);
+  }
+
+  std::string data_type;
+  if (io_config.dtype == DALI_NO_TYPE) {
+    if (io.MemberAsString("data_type", &data_type) == TRITONJSON_STATUSSUCCESS) {
+      CHECK(data_type == "TYPE_INVALID");
+    }
+  } else {
+    REQUIRE(io.MemberAsString("data_type", &data_type) == TRITONJSON_STATUSSUCCESS);
+    CHECK(data_type == to_triton_config(io_config.dtype));
+  }
+}
+
+TEST_CASE("ReadShape test") {
+  SECTION("Empty") {
+    TritonJson::Value dims;
+    TRITON_CALL(dims.Parse(R"json([])json"));
+    CHECK(ReadShape(dims) == std::vector<int64_t>{});
+  }
+
+  SECTION("Single-dim") {
+    TritonJson::Value dims;
+    TRITON_CALL(dims.Parse(R"json([-1])json"));
+    CHECK(ReadShape(dims) == std::vector<int64_t>{-1});
+  }
+
+  SECTION("Multi-dim") {
+    TritonJson::Value dims;
+    TRITON_CALL(dims.Parse(R"json([3, 2, 1])json"));
+    CHECK(ReadShape(dims) == std::vector<int64_t>{3, 2, 1});
+  }
+}
+
+TEST_CASE("IO config validation") {
+  TritonJson::Value io_config;
+  TRITON_CALL(io_config.Parse(R"json({
+    "name": "io0",
+    "dims": [3, 2, 1],
+    "data_type": "TYPE_FP32"
+  })json"));
+
+  SECTION("Matching config") {
+    ValidateIOConfig(io_config, IOConfig("io0", DALI_FLOAT, {{3, 2, 1}}));
+    ValidateIOConfig(io_config, IOConfig("io0", DALI_NO_TYPE, {{3, 2, 1}}));
+    ValidateIOConfig(io_config, IOConfig("io0", DALI_FLOAT, {}));
+  }
+
+  SECTION("Mismatching dtype") {
+    REQUIRE_THROWS_WITH(
+      ValidateIOConfig(io_config, IOConfig("io0", DALI_INT32, {{3, 2, 1}})),
+      Contains("Data type defined in config: TYPE_FP32") &&
+      Contains("Data type defined in pipeline: TYPE_INT32"));
+  }
+
+  SECTION("Mismatching ndims") {
+    REQUIRE_THROWS_WITH(
+      ValidateIOConfig(io_config, IOConfig("io0", DALI_FLOAT, {{-1, -1, -1, -1}})),
+      Contains("Number of dimensions defined in config: 3") &&
+      Contains("Number of dimensions defined in pipeline: 4"));
+  }
+
+  SECTION("Mismatching shapes") {
+    REQUIRE_THROWS_WITH(
+      ValidateIOConfig(io_config, IOConfig("io0", DALI_FLOAT, {{3, 2, 2}})),
+      Contains("Dims defined in config: {3, 2, 1}") &&
+      Contains("Dims defined in pipeline: {3, 2, 2}"));
+  }
+}
+
+TEST_CASE("IOs config validation") {
+  TritonJson::Value ios;
+  TRITON_CALL(ios.Parse(R"json([
+    {
+      "name": "io1",
+      "dims": [3, 2, 1],
+      "data_type": "TYPE_FP32"
+    },
+    {
+      "name": "io0",
+      "dims": [1, 2, -1],
+      "data_type": "TYPE_FP16"
+    }
+  ])json"));
+
+  SECTION("Correct config") {
+    ValidateIOsConfig(ios, {IOConfig("io0"), IOConfig("io1")});
+  }
+
+  SECTION("Missing config") {
+    REQUIRE_THROWS_WITH(
+      (ValidateIOsConfig(ios, {IOConfig("io0"), IOConfig("io1"), IOConfig("io3")})),
+      Contains("Missing config for \"io3\""));
+  }
+}
+
+TEST_CASE("IO auto config") {
+  IOConfig io_config_full("io", DALI_FLOAT, {{-1, -1, 3}});
+  IOConfig io_config_notype("io", DALI_NO_TYPE, {{-1, -1, 3}});
+  IOConfig io_config_noshape("io", DALI_FLOAT, {});
+  
+  TritonJson::Value io_empty;
+  TRITON_CALL(io_empty.Parse(R"json({})json"));
+
+  TritonJson::Value io_full;
+  TRITON_CALL(io_full.Parse(R"json({
+    "name": "io",
+    "dims": [3, 2, 3],
+    "data_type": "TYPE_FP32"
+  })json"));
+
+  TritonJson::Value io_notype;
+  TRITON_CALL(io_notype.Parse(R"json({
+    "name": "io",
+    "dims": [3, 2, 3]
+  })json"));
+
+  TritonJson::Value io_noshape;
+  TRITON_CALL(io_noshape.Parse(R"json({
+    "name": "io",
+    "data_type": "TYPE_FP32"
+  })json"));
+
+  SECTION("Full auto-config") {
+    TritonJson::Value result(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_empty, io_config_full, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{-1, -1, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_full, io_config_full, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_notype, io_config_full, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_noshape, io_config_full, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{-1, -1, 3}}));
+  }
+
+  SECTION("No-type auto-config") {
+    TritonJson::Value result(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_empty, io_config_notype, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_NO_TYPE, {{-1, -1, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_full, io_config_notype, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_notype, io_config_notype, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_NO_TYPE, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_noshape, io_config_notype, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{-1, -1, 3}}));
+  }
+
+  SECTION("No-shape auto-config") {
+    TritonJson::Value result(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_empty, io_config_noshape, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_full, io_config_noshape, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_notype, io_config_noshape, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {{3, 2, 3}}));
+
+    result = TritonJson::Value(TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(io_noshape, io_config_noshape, result);
+    CheckIOConfigEquals(result, IOConfig("io", DALI_FLOAT, {}));
+  }
+}
+
+TEST_CASE("IOs validation") {
+  TritonJson::Value ios(TritonJson::ValueType::ARRAY);
+  TRITON_CALL(ios.Parse(R"json([
+  {
+    "name": "io1",
+    "dims": [3, 2, 3],
+    "data_type": "TYPE_FP32"
+  },
+  {
+    "name": "io2",
+    "dims": [1, 1], 
+    "data_type": "TYPE_FP16"
+  }
+  ])json"));
+
+  SECTION("Correct config") {
+    std::vector<IOConfig> ios_config = {
+      IOConfig("io1", DALI_FLOAT, {{3, 2, 3}}),
+      IOConfig("io2", DALI_FLOAT16, {{1, 1}})
+    };
+    ValidateIOsConfig(ios, ios_config);
+  }
+
+  SECTION("Missing input") {
+    std::vector<IOConfig> ios_config = {
+      IOConfig("io1", DALI_FLOAT, {{3, 2, 3}}),
+      IOConfig("io2", DALI_FLOAT16, {{1, 1}}),
+      IOConfig("io3", DALI_UINT16, {{1}})
+    };
+
+    REQUIRE_THROWS_WITH(ValidateIOsConfig(ios, ios_config),
+                        Contains("Missing config for \"io3\""));
+  }
+}
+
+TEST_CASE("IOs auto-config") {
+  TritonJson::Value ios(TritonJson::ValueType::ARRAY);
+  TRITON_CALL(ios.Parse(R"json([
+  {
+    "name": "io1",
+    "dims": [3, 2, 3],
+    "data_type": "TYPE_FP32",
+    "allow_ragged_batches": true
+  },
+  {
+    "name": "io2",
+    "dims": [5, 5]
+  }
+  ])json"));
+
+  std::vector<IOConfig> ios_config = {
+    IOConfig("io1", DALI_FLOAT, {{3, 2, 3}}),
+    IOConfig("io2", DALI_FLOAT16, {{5, 5}}),
+    IOConfig("io3", DALI_UINT16, {{4}})
+  };
+
+  SECTION("Inputs auto-config") {
+    TritonJson::Value inputs_conf(TritonJson::ValueType::ARRAY);
+    AutofillInputsConfig(ios, ios_config, inputs_conf);
+
+    for (auto &config: ios_config) {
+      TritonJson::Value inp_object;
+      REQUIRE(FindObjectByName(inputs_conf, config.name, &inp_object));
+      bool ragged_batches;
+      REQUIRE(
+        inp_object.MemberAsBool("allow_ragged_batches", &ragged_batches) == TRITONJSON_STATUSSUCCESS
+      );
+      REQUIRE(ragged_batches);
+      CheckIOConfigEquals(inp_object, config);
+    }
+  }
+
+  SECTION("Outputs auto-config") {
+    TritonJson::Value outputs_conf(TritonJson::ValueType::ARRAY);
+    AutofillInputsConfig(ios, ios_config, outputs_conf);
+
+    for (auto &config: ios_config) {
+      TritonJson::Value out_object;
+      REQUIRE(FindObjectByName(outputs_conf, config.name, &out_object));
+      CheckIOConfigEquals(out_object, config);
+    }
+  }
+}
+
+}}}}  // namespace triton::backend::dali::test

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020 NVIDIA CORPORATION
+# Copyright (c) 2020-2022 NVIDIA CORPORATION
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -50,6 +50,10 @@ else ()
     set(DALI_LIBRARIES dali dali_core dali_kernels dali_operators)
 endif ()  # TRITON_DALI_SKIP_DOWNLOAD
 
+set(DALI_INCLUDE_DIR ${DALI_INCLUDE_DIR} PARENT_SCOPE)
+set(DALI_LIB_DIR ${DALI_LIB_DIR} PARENT_SCOPE)
+set(DALI_LIBRARIES ${DALI_LIBRARIES} PARENT_SCOPE)
+
 message(STATUS "DALI includes dir: " ${DALI_INCLUDE_DIR})
 message(STATUS "DALI libs dir: " ${DALI_LIB_DIR})
 message(STATUS "DALI libs: " ${DALI_LIBRARIES})
@@ -61,6 +65,7 @@ add_library(
         $<$<NOT:$<BOOL:${TRITON_DALI_SKIP_DOWNLOAD}>>:dali_whl>
 )
 
+set_property(TARGET dali_executor PROPERTY CXX_STANDARD 17)
 target_include_directories(dali_executor PUBLIC BEFORE
         ${tritondalibackend_SOURCE_DIR}
         ${DALI_INCLUDE_DIR})

--- a/src/utils/triton.h
+++ b/src/utils/triton.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021 NVIDIA CORPORATION
+// Copyright (c) 2021-2022 NVIDIA CORPORATION
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,10 @@
 #ifndef DALI_BACKEND_UTILS_TRITON_H_
 #define DALI_BACKEND_UTILS_TRITON_H_
 
+#include <dali/c_api.h>
+
 #include "src/dali_executor/io_descriptor.h"
-#include "src/dali_executor/utils/dali.h"
+// #include "src/dali_executor/utils/dali.h"
 #include "src/dali_executor/utils/utils.h"
 #include "triton/backend/backend_model.h"
 #include "triton/backend/backend_model_instance.h"
@@ -119,6 +121,18 @@ class TritonError : public UniqueHandle<TRITONSERVER_Error *, TritonError>, publ
   static TritonError Unknown(const std::string &msg) {
     auto err =
         TRITONSERVER_ErrorNew(TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN, msg.c_str());
+    return TritonError(err);
+  }
+
+  static TritonError InvalidArg(const std::string &msg) {
+    auto err = TRITONSERVER_ErrorNew(TRITONSERVER_Error_Code::TRITONSERVER_ERROR_INVALID_ARG,
+                                     msg.c_str());
+    return TritonError(err);
+  }
+
+  static TritonError Internal(const std::string &msg) {
+    auto err = TRITONSERVER_ErrorNew(TRITONSERVER_Error_Code::TRITONSERVER_ERROR_INTERNAL,
+                                     msg.c_str());
     return TritonError(err);
   }
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <string>
+#include <sstream>
 
 namespace triton { namespace backend { namespace dali {
 
@@ -64,6 +65,23 @@ inline int from_string<int>(const std::string& str) {
 template<>
 inline std::string from_string<std::string>(const std::string& str) {
   return str;
+}
+
+template <typename T>
+std::string vec_to_string(const std::vector<T> &vec, const std::string &lbracket = "{",
+                          const std::string &rbracket = "}", const std::string &delim = ", ") {
+  std::stringstream ss;
+  ss << lbracket.c_str();
+  auto it = vec.begin();
+  if (vec.size() > 0) {
+    ss << *it;
+    for (++it; it != vec.end(); ++it) {
+      ss << delim;
+      ss << *it;
+    }
+  }
+  ss << rbracket.c_str();
+  return ss.str();
 }
 
 }}}  // namespace triton::backend::dali


### PR DESCRIPTION
This PR provides tools to validate and auto-fill configuration of DALI backend.

The configuration in Triton is stored as TritonJson::Value. The implemented Validate* functions check the values stored in JSON and compare them with values passed as arguments - those will be later acquired from DALI pipeline. 
The Autofill* functions, additionally to validating, produce new auto-filled TritonJson that will be used as new model configuration.

Changes to CMake were required to use C++17 and also to make Triton libraries available in test binary.

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>