### PR TITLE
Fix version picking for DALI nightly. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ set(DALI_VERSION "" CACHE STRING
     "DALI version that should be downloaded by the build system.
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-if(NOT DALI_VERSION AND NOT TRITON_DALI_SKIP_DOWNLOAD)
-    file(READ ${tritondalibackend_SOURCE_DIR}/DALI_VERSION DALI_VERSION)
-endif()
 
 set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
     "URL of the Index, from which DALI will be downloaded by the build system.
@@ -61,16 +58,6 @@ set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" 
 set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
     "Extra options for `pip install` call, that downloads DALI wheel.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
-
-if (${TRITON_DALI_SKIP_DOWNLOAD})
-    message(STATUS "Skipping DALI download.")
-else ()
-    message(STATUS "Building with DALI version: ${DALI_VERSION}")
-    message(STATUS "DALI wheel extra index url: ${DALI_EXTRA_INDEX_URL}")
-    message(STATUS "DALI wheel package name: ${DALI_DOWNLOAD_PKG_NAME}")
-    message(STATUS "Downloading DALI with extra options: ${DALI_DOWNLOAD_EXTRA_OPTIONS}")
-endif ()
-
 
 # Dependencies
 #
@@ -110,6 +97,20 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-f
 set(DALI_DOWNLOAD_PKG_NAME "nvidia-dali-cuda${CUDAToolkit_VERSION_MAJOR}0" CACHE STRING
         "DALI pip package name to download.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
+
+if(NOT DALI_VERSION AND NOT DALI_DOWNLOAD_PKG_NAME MATCHES "nightly" AND NOT TRITON_DALI_SKIP_DOWNLOAD)
+    file(READ ${tritondalibackend_SOURCE_DIR}/DALI_VERSION DALI_VERSION)
+    string(STRIP "${DALI_VERSION}" DALI_VERSION)
+endif()
+
+if (${TRITON_DALI_SKIP_DOWNLOAD})
+    message(STATUS "Skipping DALI download.")
+else ()
+    message(STATUS "Building with DALI version: ${DALI_VERSION}")
+    message(STATUS "DALI wheel extra index url: ${DALI_EXTRA_INDEX_URL}")
+    message(STATUS "DALI wheel package name: ${DALI_DOWNLOAD_PKG_NAME}")
+    message(STATUS "Downloading DALI with extra options: ${DALI_DOWNLOAD_EXTRA_OPTIONS}")
+endif ()
 
 if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/cmake/dalienv-extra_args.yml.in
+++ b/cmake/dalienv-extra_args.yml.in
@@ -1,8 +1,0 @@
-name: dalienv
-dependencies:
-  - python=3.8
-  - pip
-  - pip:
-      - --extra-index-url @DALI_EXTRA_INDEX_URL@
-      - @DALI_DOWNLOAD_EXTRA_OPTIONS@
-      - @DALI_DOWNLOAD_PKG_NAME@==@DALI_VERSION@

--- a/cmake/dalienv.yml.in
+++ b/cmake/dalienv.yml.in
@@ -4,4 +4,5 @@ dependencies:
   - pip
   - pip:
       - --extra-index-url @DALI_EXTRA_INDEX_URL@
-      - @DALI_DOWNLOAD_PKG_NAME@==@DALI_VERSION@
+      - @CONF_DOWNLOAD_PKG@
+      @CONF_DOWNLOAD_EXTRA_OPTIONS@

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -29,10 +29,15 @@ set(
 include(${tritondalibackend_SOURCE_DIR}/cmake/dali.cmake)
 
 if(DALI_DOWNLOAD_EXTRA_OPTIONS)
-    configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv-extra_args.yml.in dalienv.yml @ONLY)
-else()
-    configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml @ONLY)
+    set(CONF_DOWNLOAD_EXTRA_OPTIONS "- ${DALI_DOWNLOAD_EXTRA_OPTIONS}")
 endif()
+
+set(CONF_DOWNLOAD_PKG "${DALI_DOWNLOAD_PKG_NAME}")
+if(DALI_VERSION)
+    string(APPEND CONF_DOWNLOAD_PKG "==${DALI_VERSION}")
+endif()
+
+configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml @ONLY)
 
 add_custom_command(
     OUTPUT dali_env


### PR DESCRIPTION
Fixes the version of DALI package for DALI nightly. 
If during build DALI nightly is downloaded it chooses latest version instead of the version saved in DALI_VERSION. 

This PR also simplifies configuration of miniconda env. It leaves only one .in file and creates new CONF_* variables in cmake to correctly configure it.

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>