### PR TITLE
Hardcode Conda environment path

### DIFF
--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -84,6 +84,7 @@ install(
 
 set(DALI_CONDA_ENVIRONMENT_DIR /opt/tritonserver/backends/dali/conda/envs)
 target_compile_definitions(dali_executor PUBLIC CONDA_ENVIRONMENT=${DALI_CONDA_ENVIRONMENT_DIR}/dalienv)
+message(STATUS "Conda environment location: ${DALI_CONDA_ENVIRONMENT_DIR}")
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dalienv

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -82,7 +82,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali
 )
 
-set(DALI_CONDA_ENVIRONMENT_DIR ${CMAKE_INSTALL_PREFIX}/backends/dali/conda/envs)
+set(DALI_CONDA_ENVIRONMENT_DIR /opt/tritonserver/backends/dali/conda/envs)
 target_compile_definitions(dali_executor PUBLIC CONDA_ENVIRONMENT=${DALI_CONDA_ENVIRONMENT_DIR}/dalienv)
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})


### PR DESCRIPTION
The previous way of passing CONDA_ENVIRONMENT_PATH from CMake to C++ didn't work correctly. I'm changing this to hardcode the path. I don't suspect this path to change anyway. If it changes, however, it will be an easy error to resolve.