### PR TITLE
Fix outputs auto-config. Add max_batch_size validation

### DIFF
--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -22,6 +22,8 @@
 
 #include "src/config_tools/config_tools.h"
 
+#include <limits>
+
 namespace triton { namespace backend { namespace dali {
 
 
@@ -216,7 +218,12 @@ void AutofillIOConfig(TritonJson::Value &io_object, const IOConfig &io_config,
   TRITON_CALL(io_object.AssertType(common::TritonJson::ValueType::OBJECT));
   TRITON_CALL(new_io_object.AssertType(common::TritonJson::ValueType::OBJECT));
 
-  new_io_object.AddString("name", io_config.name);
+  std::string name;
+  if (io_object.MemberAsString("name", &name) == TRITONJSON_STATUSSUCCESS) {
+    new_io_object.AddString("name", name);
+  } else {
+    new_io_object.AddString("name", io_config.name);
+  }
 
   std::string new_data_type = AutofillDtypeConfig(io_object, io_config.name, io_config.dtype);
   new_io_object.AddString("data_type", new_data_type);
@@ -232,6 +239,25 @@ void ValidateIOConfig(TritonJson::Value &io_object, const IOConfig &io_config) {
   TRITON_CALL(io_object.AssertType(common::TritonJson::ValueType::OBJECT));
   ValidateDtypeConfig(io_object, io_config.name, io_config.dtype);
   ValidateShapeConfig(io_object, io_config.name, io_config.shape);
+}
+
+
+void ValidateAgainstTooManyInputs(TritonJson::Value &ins, const std::vector<IOConfig> &in_configs) {
+   for (size_t i = 0; i < ins.ArraySize(); ++i) {
+    TritonJson::Value io_object(TritonJson::ValueType::OBJECT);
+    ins.IndexAsObject(i, &io_object);
+    std::string name;
+    if (io_object.MemberAsString("name", &name) != TRITONJSON_STATUSSUCCESS) {
+      throw TritonError::InvalidArg(make_string("Missing name in IO config at position ", i));
+    }
+
+    bool in_present = std::any_of(in_configs.begin(), in_configs.end(),
+                                  [&](const auto &ioc) { return ioc.name == name; });
+    if (!in_present) {
+      throw TritonError::InvalidArg(make_string("Configuration file contains config for ", name,
+                                                " but such input is not present in the pipeline."));
+    }
+  }
 }
 
 
@@ -272,20 +298,64 @@ void AutofillIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_c
 }
 
 
-void AutofillInputsConfig(TritonJson::Value &inputs, const std::vector<IOConfig> &in_configs,
-                          TritonJson::Value &new_ios) {
-  AutofillIOsConfig<true>(inputs, in_configs, new_ios);
+void AutofillInputsConfig(TritonJson::Value &ins, const std::vector<IOConfig> &in_configs,
+                          TritonJson::Value &new_ins) {
+  TRITON_CALL(ins.AssertType(common::TritonJson::ValueType::ARRAY));
+  TRITON_CALL(new_ins.AssertType(common::TritonJson::ValueType::ARRAY));
+  ValidateAgainstTooManyInputs(ins, in_configs);
+  std::vector<TritonJson::Value> new_in_objs(in_configs.size());
+  auto end_ind = ins.ArraySize();
+  for (const auto &in_config: in_configs) {
+    TritonJson::Value in_object(TritonJson::ValueType::OBJECT);
+    auto ind = FindObjectByName(ins, in_config.name, &in_object);
+    size_t in_index;
+    if (ind) {
+      in_index = *ind;
+    } else {
+      in_index = end_ind++;
+    }
+    new_in_objs[in_index] = TritonJson::Value(new_ins, TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(in_object, in_config, new_in_objs[in_index]);
+    bool ragged_batches;
+    if (in_object.MemberAsBool("allow_ragged_batches", &ragged_batches)
+          == TRITONJSON_STATUSSUCCESS) {
+      new_in_objs[in_index].AddBool("allow_ragged_batches", ragged_batches);
+    } else {
+      new_in_objs[in_index].AddBool("allow_ragged_batches", true);
+    }
+  }
+
+  for (auto &new_in : new_in_objs) {
+    new_ins.Append(std::move(new_in));
+  }
 }
 
 
-void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfig> &out_configs,
-                           TritonJson::Value &new_ios) {
-  AutofillIOsConfig<false>(outputs, out_configs, new_ios);
+void AutofillOutputsConfig(TritonJson::Value &outs, const std::vector<IOConfig> &out_configs,
+                           TritonJson::Value &new_outs) {
+  TRITON_CALL(outs.AssertType(common::TritonJson::ValueType::ARRAY));
+  TRITON_CALL(new_outs.AssertType(common::TritonJson::ValueType::ARRAY));
+  if (outs.ArraySize() > out_configs.size()) {
+    throw TritonError::InvalidArg(
+      make_string("Invalid number of outputs in the configuration file: ", outs.ArraySize(),
+                  "\nProvided pipeline has only ", out_configs.size(), " outputs."));
+  }
+
+  std::vector<TritonJson::Value> new_out_objs(out_configs.size());
+  for (size_t i = 0; i < out_configs.size(); ++i) {
+    TritonJson::Value out_object(TritonJson::ValueType::OBJECT);
+    outs.IndexAsObject(i, &out_object);
+    new_out_objs[i] = TritonJson::Value(new_outs, TritonJson::ValueType::OBJECT);
+    AutofillIOConfig(out_object, out_configs[i], new_out_objs[i]);
+  }
+
+  for (auto &new_out : new_out_objs) {
+    new_outs.Append(std::move(new_out));
+  }
 }
 
 
 void ValidateIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_configs) {
-  TRITON_CALL(ios.AssertType(common::TritonJson::ValueType::ARRAY));
   for (const auto &io_config: io_configs) {
     TritonJson::Value io_object(TritonJson::ValueType::OBJECT);
     auto ind = FindObjectByName(ios, io_config.name, &io_object);
@@ -294,5 +364,64 @@ void ValidateIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_c
     }
     ValidateIOConfig(io_object, io_config);
   }
+}
+
+
+void ValidateInputs(TritonJson::Value &ins, const std::vector<IOConfig> &in_configs) {
+  TRITON_CALL(ins.AssertType(common::TritonJson::ValueType::ARRAY));
+  ValidateAgainstTooManyInputs(ins, in_configs);
+  for (const auto &in_config: in_configs) {
+    TritonJson::Value in_object(TritonJson::ValueType::OBJECT);
+    auto ind = FindObjectByName(ins, in_config.name, &in_object);
+    if (!ind) {
+      throw TritonError::InvalidArg(make_string("Missing config for \"", in_config.name, "\""));
+    }
+    ValidateIOConfig(in_object, in_config);
+  }
+}
+
+
+void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> out_configs) {
+  TRITON_CALL(outs.AssertType(common::TritonJson::ValueType::ARRAY));
+  if (outs.ArraySize() != out_configs.size()) {
+    throw TritonError::InvalidArg(
+      make_string("Invalid number of outputs in the configuration file: ", outs.ArraySize(),
+                  "\nProvided pipeline has ", out_configs.size(), " outputs."));
+  }
+  for (size_t i = 0; i < out_configs.size(); ++i) {
+    TritonJson::Value out_object;
+    TRITON_CALL(outs.IndexAsObject(i, &out_object));
+    ValidateIOConfig(out_object, out_configs[i]);
+  }
+}
+
+
+int ReadMaxBatchSize(TritonJson::Value &config) {
+  int64_t bs = -1;
+  config.MemberAsInt("max_batch_size", &bs);
+  if (bs > std::numeric_limits<int>::max() || bs < -1) {
+    throw TritonError::InvalidArg(make_string("Invalid value of max_batch_size: ", bs));
+  }
+  return static_cast<int>(bs);
+}
+
+
+void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_configs,
+                    const std::vector<IOConfig> &out_configs) {
+  if (ReadMaxBatchSize(config) < 1) {
+    throw TritonError::InvalidArg("Missing max_batch_size config.");
+  }
+
+  TritonJson::Value inputs(TritonJson::ValueType::ARRAY);
+  if (config.MemberAsArray("input", &inputs) != TRITONJSON_STATUSSUCCESS) {
+    throw TritonError::InvalidArg("Missing inputs config.");
+  }
+  ValidateInputs(inputs, in_configs);
+
+  TritonJson::Value outputs(TritonJson::ValueType::ARRAY);
+  if (config.MemberAsArray("output", &outputs) != TRITONJSON_STATUSSUCCESS) {
+    throw TritonError::InvalidArg("Missing outputs config.");
+  }
+  ValidateOutputs(outputs, out_configs);
 }
 }}}  // namespace triton::backend::dali

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -261,43 +261,6 @@ void ValidateAgainstTooManyInputs(TritonJson::Value &ins, const std::vector<IOCo
 }
 
 
-template <bool input>
-void AutofillIOsConfig(TritonJson::Value &ios, const std::vector<IOConfig> &io_configs,
-                       TritonJson::Value &new_ios) {
-  TRITON_CALL(ios.AssertType(common::TritonJson::ValueType::ARRAY));
-  TRITON_CALL(new_ios.AssertType(common::TritonJson::ValueType::ARRAY));
-
-  std::vector<TritonJson::Value> new_io_objs(io_configs.size());
-  auto end_ind = ios.ArraySize();
-  for (const auto &io_config: io_configs) {
-    TritonJson::Value io_object(TritonJson::ValueType::OBJECT);
-    auto ind = FindObjectByName(ios, io_config.name, &io_object);
-    size_t io_index;
-    if (ind) {
-      io_index = *ind;
-    } else {
-      io_index = end_ind++;
-    }
-    new_io_objs[io_index] = TritonJson::Value(new_ios, TritonJson::ValueType::OBJECT);
-    AutofillIOConfig(io_object, io_config, new_io_objs[io_index]);
-
-    if (input) {
-      bool ragged_batches;
-      if (io_object.MemberAsBool("allow_ragged_batches", &ragged_batches)
-            == TRITONJSON_STATUSSUCCESS) {
-        new_io_objs[io_index].AddBool("allow_ragged_batches", ragged_batches);
-      } else {
-        new_io_objs[io_index].AddBool("allow_ragged_batches", true);
-      }
-    }
-  }
-
-  for (auto &new_io : new_io_objs) {
-    new_ios.Append(std::move(new_io));
-  }
-}
-
-
 void AutofillInputsConfig(TritonJson::Value &ins, const std::vector<IOConfig> &in_configs,
                           TritonJson::Value &new_ins) {
   TRITON_CALL(ins.AssertType(common::TritonJson::ValueType::ARRAY));

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -149,8 +149,8 @@ void AutofillInputsConfig(TritonJson::Value &inputs, const std::vector<IOConfig>
  * @brief Validates outputs array against provided config values
  * Outputs auto-configured array to new_outputs.
  *
- * It's assumed that outputs in the config file have the same order as in the pipeline.
- * If the config gives an output a name, it overrides the name coming from the pipeline.
+ * It's assumed that outputs in the config file have the same order as those in the DALI pipeline.
+ * If the config sets the name of an output, it overrides the name specified in the DALI pipeline.
  */
 void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfig> &out_configs,
                            TritonJson::Value &new_outputs);
@@ -159,7 +159,8 @@ void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfi
 /**
  * @brief Validate outputs array against provided config values
  *
- * Names of the outputs in the config file may not match names of the outputs in the pipeline.
+ * Names of the outputs in the config file do not need to match the names of the outputs
+ * specified in the DALI pipeline.
  */
 void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> out_configs);
 

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -183,8 +183,10 @@ TEST_CASE("Outputs validation") {
     };
 
     REQUIRE_THROWS_WITH(ValidateOutputs(ios, ios_config),
-                        Contains("Invalid number of outputs in the configuration file: 2"
-                                 "\nProvided pipeline has 3 outputs."));
+                        Contains("The number of outputs specified in the DALI pipeline and the"
+                                 " configuration file do not match."
+                                 "\nModel config outputs: 2"
+                                 "\nPipeline outputs: 3"));
   }
 }
 
@@ -442,7 +444,7 @@ TEST_CASE("Read max_batch_size") {
     })json"));
 
     REQUIRE_THROWS_WITH(ReadMaxBatchSize(config),
-                        Contains("Invalid value of max_batch_size: -2"));
+                        Contains("Invalid value of max_batch_size in model configuration: -2"));
   }
 }
 
@@ -536,7 +538,7 @@ TEST_CASE("Validate config") {
     })json"));
 
     REQUIRE_THROWS_WITH(ValidateConfig(config, ins_config, outs_config),
-                        Contains("Missing max_batch_size config."));
+                        Contains("Missing max_batch_size field in model configuration."));
   }
 }
 


### PR DESCRIPTION
It fixes handling outputs in auto-config implementation. 
It differentiates the behavior regarding inputs and outputs.
inputs:
The inputs in the config file are referenced by they names (they have to match the names given in the pipeline), so they can be freely reordered in the config file.

outputs:
Names of the outputs in the config file don't have to match the output names from the pipeline - they are rather used to override the names of the pipeline outputs. So in their case, order matters and is assumed to match the order of pipeline outputs. 

I extended the docstring of the config methods to contain this information. 


New methods:
`ReadMaxBatchSize` - reads and validates max batch size in the config

`ValidateConfig` - composition of ValidateInputs, ValidateOuptputs and ReadMaxBatchSize

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>