### PR TITLE
Validate config file against pipeline.

### DIFF
--- a/qa/L0_config_validation/client.py
+++ b/qa/L0_config_validation/client.py
@@ -31,7 +31,7 @@ def assert_error(func, *args, contains=None):
   except InferenceServerException as err:
     err_msg = str(err)
   if contains is not None:
-    assert contains in err_msg, 'Error message:\n' + err_msg + '\nshould contain:\n' + contains
+    assert contains in err_msg, f'Error message:\n  {err_msg}\nshould contain:\n{contains}'
 
 def test_loading(url):
   client = t_client.InferenceServerClient(url=url)

--- a/qa/L0_config_validation/client.py
+++ b/qa/L0_config_validation/client.py
@@ -1,0 +1,75 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import tritonclient.grpc as t_client
+from tritonclient.utils import InferenceServerException
+import argparse
+
+def assert_error(func, *args, contains=None):
+  try:
+    func(*args)
+    msg = "Should raise error: " + ', '.join([str(arg) for arg in args])
+    assert False, msg
+  except InferenceServerException as err:
+    err_msg = str(err)
+  if contains is not None:
+    assert contains in err_msg, 'Error message:\n' + err_msg + '\nshould contain:\n' + contains
+
+def test_loading(url):
+  client = t_client.InferenceServerClient(url=url)
+
+  client.load_model('model0_gpu_valid')
+  print('model0_gpu_valid OK')
+
+  assert_error(client.load_model, 'model1_gpu_invalid_i_type',
+               contains='Invalid argument: Mismatch of data_type config for "DALI_INPUT_1".\n'
+                        'Data type defined in config: TYPE_FP32\n'
+                        'Data type defined in pipeline: TYPE_FP16')
+  print('model1_gpu_invalid_i_type OK')
+
+  assert_error(client.load_model, 'model2_gpu_invalid_o_ndim',
+               contains='Invalid argument: Mismatch in number of dimensions for "DALI_OUTPUT_1"\n'
+                        'Number of dimensions defined in config: 2\n'
+                        'Number of dimensions defined in pipeline: 1')
+  print('model2_gpu_invalid_o_ndim OK')
+
+  client.load_model('model3_cpu_valid')
+  print('model3_cpu_valid OK')
+
+  assert_error(client.load_model, 'model4_cpu_invalid_missing_output',
+               contains='The number of outputs specified in the DALI pipeline '
+                        'and the configuration file do not match.\n'
+                        'Model config outputs: 1\n'
+                        'Pipeline outputs: 2')
+  print('model4_cpu_invalid_missing_output OK')
+
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-u', '--url', type=str, required=False, default='localhost:8001',
+                        help='Inference server GRPC URL. Default is localhost:8001.')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+  args = parse_args()
+  test_loading(args.url)

--- a/qa/L0_config_validation/model_repository/model0_gpu_valid/config.pbtxt
+++ b/qa/L0_config_validation/model_repository/model0_gpu_valid/config.pbtxt
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: "model0_gpu_valid"
+backend: "dali"
+max_batch_size: 32
+input [
+  {
+    name: "DALI_INPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+input [
+  {
+    name: "DALI_INPUT_1"
+    data_type: TYPE_FP16
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_1"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 32 ]
+  max_queue_delay_microseconds: 500
+}

--- a/qa/L0_config_validation/model_repository/model1_gpu_invalid_i_type/config.pbtxt
+++ b/qa/L0_config_validation/model_repository/model1_gpu_invalid_i_type/config.pbtxt
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: "model1_gpu_invalid_i_type"
+backend: "dali"
+max_batch_size: 32
+input [
+  {
+    name: "DALI_INPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+input [
+  {
+    name: "DALI_INPUT_1"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_1"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 32 ]
+  max_queue_delay_microseconds: 500
+}

--- a/qa/L0_config_validation/model_repository/model2_gpu_invalid_o_ndim/config.pbtxt
+++ b/qa/L0_config_validation/model_repository/model2_gpu_invalid_o_ndim/config.pbtxt
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: "model2_gpu_invalid_o_ndim"
+backend: "dali"
+max_batch_size: 32
+input [
+  {
+    name: "DALI_INPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+input [
+  {
+    name: "DALI_INPUT_1"
+    data_type: TYPE_FP16
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_1"
+    data_type: TYPE_FP32
+    dims: [ 1, -1 ]
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 32 ]
+  max_queue_delay_microseconds: 500
+}

--- a/qa/L0_config_validation/model_repository/model3_cpu_valid/config.pbtxt
+++ b/qa/L0_config_validation/model_repository/model3_cpu_valid/config.pbtxt
@@ -1,0 +1,69 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: "model3_cpu_valid"
+backend: "dali"
+max_batch_size: 32
+input [
+  {
+    name: "DALI_INPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+input [
+  {
+    name: "DALI_INPUT_1"
+    data_type: TYPE_FP16
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_1"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 32 ]
+  max_queue_delay_microseconds: 500
+}
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]

--- a/qa/L0_config_validation/model_repository/model4_cpu_invalid_missing_output/config.pbtxt
+++ b/qa/L0_config_validation/model_repository/model4_cpu_invalid_missing_output/config.pbtxt
@@ -1,0 +1,61 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: "model4_cpu_invalid_missing_output"
+backend: "dali"
+max_batch_size: 32
+input [
+  {
+    name: "DALI_INPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+input [
+  {
+    name: "DALI_INPUT_1"
+    data_type: TYPE_FP16
+    dims: [ -1 ]
+    allow_ragged_batch: true
+  }
+]
+
+output [
+  {
+    name: "DALI_OUTPUT_0"
+    data_type: TYPE_FP32
+    dims: [ -1 ]
+  }
+]
+
+dynamic_batching {
+  preferred_batch_size: [ 32 ]
+  max_queue_delay_microseconds: 500
+}
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]

--- a/qa/L0_config_validation/pipeline_cpu.py
+++ b/qa/L0_config_validation/pipeline_cpu.py
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import nvidia.dali as dali
+import nvidia.dali.fn as fn
+import multiprocessing as mp
+from nvidia.dali.plugin.triton import autoserialize
+
+@autoserialize
+@dali.pipeline_def(batch_size=256, num_threads=min(mp.cpu_count(), 4), device_id=None,
+                   output_dtype=[dali.types.FLOAT, None], output_ndim=[1, 1])
+def pipeline():
+  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
+  inp2 = fn.external_source(device='cpu', name='DALI_INPUT_1', dtype=dali.types.FLOAT16)
+  return inp1 / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2

--- a/qa/L0_config_validation/pipeline_gpu.py
+++ b/qa/L0_config_validation/pipeline_gpu.py
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import nvidia.dali as dali
+import nvidia.dali.fn as fn
+import multiprocessing as mp
+from nvidia.dali.plugin.triton import autoserialize
+
+@autoserialize
+@dali.pipeline_def(batch_size=256, num_threads=min(mp.cpu_count(), 4), device_id=0,
+                   output_dtype=[dali.types.FLOAT, None], output_ndim=[1, 1])
+def pipeline():
+  inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0')
+  inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1', dtype=dali.types.FLOAT16)
+  return inp1.gpu() / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2

--- a/qa/L0_config_validation/setup.sh
+++ b/qa/L0_config_validation/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+mkdir -p model_repository/model0_gpu_valid/1
+cp pipeline_gpu.py model_repository/model0_gpu_valid/1/dali.py
+echo "model0_gpu_valid ready"
+
+mkdir -p model_repository/model1_gpu_invalid_i_type/1
+cp pipeline_gpu.py model_repository/model1_gpu_invalid_i_type/1/dali.py
+echo "model1_gpu_invalid_i_type ready"
+
+mkdir -p model_repository/model2_gpu_invalid_o_ndim/1
+cp pipeline_gpu.py model_repository/model2_gpu_invalid_o_ndim/1/dali.py
+echo "model2_gpu_invalid_o_ndim ready"
+
+mkdir -p model_repository/model3_cpu_valid/1
+cp pipeline_cpu.py model_repository/model3_cpu_valid/1/dali.py
+echo "model3_cpu_valid ready"
+
+mkdir -p model_repository/model4_cpu_invalid_missing_output/1
+cp pipeline_cpu.py model_repository/model4_cpu_invalid_missing_output/1/dali.py
+echo "model4_cpu_invalid_missing_output ready"

--- a/qa/L0_config_validation/test.sh
+++ b/qa/L0_config_validation/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+: ${GRPC_ADDR:=${1:-"localhost:8001"}}
+
+python client.py -u $GRPC_ADDR

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -93,7 +93,7 @@ std::optional<size_t> FindObjectByName(TritonJson::Value &array, const std::stri
       return {i};
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -162,7 +162,7 @@ void AutofillOutputsConfig(TritonJson::Value &outputs, const std::vector<IOConfi
  * Names of the outputs in the config file do not need to match the names of the outputs
  * specified in the DALI pipeline.
  */
-void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> out_configs);
+void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> &out_configs);
 
 
 /**

--- a/src/dali_executor/dali_pipeline.cc
+++ b/src/dali_executor/dali_pipeline.cc
@@ -107,9 +107,9 @@ std::vector<std::string> DaliPipeline::ListInputs() {
 std::optional<std::vector<int64_t>> DaliPipeline::GetInputShape(const std::string &name) {
   int ndim = daliGetExternalInputNdim(&handle_, name.c_str());
   if (ndim >= 0) {
-    return {std::vector<int64_t>(ndim, -1)};
+    return std::vector<int64_t>(ndim, -1);
   } else {
-    return {};
+    return std::nullopt;
   }
 }
 
@@ -131,9 +131,9 @@ std::string DaliPipeline::GetOutputName(int id) {
 std::optional<std::vector<int64_t>> DaliPipeline::GetDeclaredOutputShape(int id) {
   int ndim = daliGetDeclaredOutputNdim(&handle_, id);
   if (ndim >= 0) {
-    return {std::vector<int64_t>(ndim, -1)};
+    return std::vector<int64_t>(ndim, -1);
   } else {
-    return {};
+    return std::nullopt;
   }
 }
 

--- a/src/dali_executor/dali_pipeline.h
+++ b/src/dali_executor/dali_pipeline.h
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <optional>
 
 #include "src/dali_executor/io_descriptor.h"
 #include "src/dali_executor/utils/dali.h"
@@ -127,6 +128,41 @@ class DaliPipeline {
   void SetInput(const IDescr& io_descr, bool force_no_copy = true);
 
   void PutOutput(void* destination, int output_idx, device_type_t destination_device);
+
+  /**
+   * @brief Get list of external inputs names in the pipeline.
+   */
+  std::vector<std::string> ListInputs();
+
+  /**
+   * @brief Get declared expected shape of the input with a given name.
+   */
+  std::optional<std::vector<int64_t>> GetInputShape(const std::string &name);
+
+  /**
+   * @brief Get declared exptect data type of the input with a given name.
+   */
+  dali_data_type_t GetInputType(const std::string &name);
+
+  /**
+   * @brief Get name of the pipeline output with a given id.
+   */
+  std::string GetOutputName(int id);
+
+  /**
+   * @brief Get shape declared for the pipeline output with a given id.
+   */
+  std::optional<std::vector<int64_t>> GetDeclaredOutputShape(int id);
+
+  /**
+   * @brief Get declared output data type for the pipeline output with a given id.
+   */
+  dali_data_type_t GetDeclaredOutputType(int id);
+
+  /**
+   * @brief Get max batch size of the pipeline.
+   */
+  int GetMaxBatchSize();
 
   /**
    * @brief Wait for the work scheduled on the copy stream.

--- a/src/dali_executor/utils/dali.h
+++ b/src/dali_executor/utils/dali.h
@@ -55,6 +55,7 @@ using ::dali::TensorShape;
 using ::dali::ThreadPool;
 using ::dali::UniqueHandle;
 using ::dali::volume;
+using ::dali::CPU_ONLY_DEVICE_ID;
 
 
 inline int64_t dali_type_size(dali_data_type_t type) {

--- a/src/dali_model.cc
+++ b/src/dali_model.cc
@@ -27,6 +27,7 @@ namespace triton { namespace backend { namespace dali {
 TRITONSERVER_Error* DaliModel::Create(TRITONBACKEND_Model* triton_model, DaliModel** state) {
   try {
     *state = new DaliModel(triton_model);
+    return nullptr;
   } catch (TritonError& e) {
     return e.release();
   } catch (DALIException& e) {

--- a/src/dali_model.cc
+++ b/src/dali_model.cc
@@ -25,16 +25,16 @@
 namespace triton { namespace backend { namespace dali {
 
 TRITONSERVER_Error* DaliModel::Create(TRITONBACKEND_Model* triton_model, DaliModel** state) {
-  TRITONSERVER_Error* error = nullptr;  // success
   try {
     *state = new DaliModel(triton_model);
+  } catch (TritonError& e) {
+    return e.release();
+  } catch (DALIException& e) {
+    return TritonError::Unknown(make_string("Error while instantiating DALI pipeline: ", e.what()))
+             .release();
   } catch (const std::exception& e) {
-    LOG_MESSAGE(TRITONSERVER_LOG_ERROR, e.what());
-    error = TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_UNKNOWN,
-                                  make_string("DALI Backend error: ", e.what()).c_str());
+    return TritonError::Unknown(make_string("DALI Backend error: ", e.what())).release();
   }
-
-  return error;
 }
 
 }}}  // namespace triton::backend::dali

--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -200,14 +200,11 @@ class DaliModel : public ::triton::backend::BackendModel {
     triton::common::TritonJson::Value instance_groups;
     bool found_inst_groups = model_config_.Find("instance_group", &instance_groups);
     if (found_inst_groups) {
-      std::cout << "Found inst groups" << std::endl;
       return ReadDeviceFromInstanceGroups(instance_groups);
     } else {
       // config doesn't specify any GPU so we can choose any available
       int dev_count = 0;
-      std::cout << "No inst groups; dev count: ";
       CUDA_CALL_GUARD(cudaGetDeviceCount(&dev_count));
-      std::cout << dev_count << std::endl;
       if (dev_count > 0) {
         return 0;
       } else {
@@ -226,7 +223,6 @@ class DaliModel : public ::triton::backend::BackendModel {
       inst_groups.IndexAsObject(i, &inst_group);
       std::string kind_str;
       if (inst_group.MemberAsString("kind", &kind_str) == TRITONJSON_STATUSSUCCESS) {
-        std::cout << "\t" << kind_str << std::endl;
         if (kind_str == "KIND_GPU") {
           triton::common::TritonJson::Value dev_array;
           if (inst_group.Find("gpus", &dev_array) && dev_array.ArraySize() > 0) {

--- a/src/dali_model_instance.h
+++ b/src/dali_model_instance.h
@@ -101,7 +101,7 @@ class DaliModelInstance : public ::triton::backend::BackendModelInstance {
   InputsInfo GenerateInputs(const std::vector<TritonRequest>& requests);
 
   int32_t GetDaliDeviceId() {
-    return !CudaStream() ? ::dali::CPU_ONLY_DEVICE_ID : device_id_;
+    return !CudaStream() ? CPU_ONLY_DEVICE_ID : device_id_;
   }
 
   /**


### PR DESCRIPTION
Most of the volume of this PR is made by config files for test models - they're mostly just copy-paste with slight modifications (to introduce validation errors).

The significant parts are in files: 
- `dali_pipeline.h/cc` - methods for fetching inputs and outputs info from the pipeline.
- `dali_model.h` - instantiating pipeline (with choosing a device for that) and calling actual validation.

Tests are implemented in `client.py`. They try to load each of the prepared models and expect some kind of error. 