### PR TITLE
Enable dynamic batching when auto-completing model config

### DIFF
--- a/qa/L0_autoconfig/model_repository/partial_autoconfig/config.pbtxt
+++ b/qa/L0_autoconfig/model_repository/partial_autoconfig/config.pbtxt
@@ -43,6 +43,6 @@ output [
 ]
 
 dynamic_batching {
-  preferred_batch_size: [ 32 ]
+  preferred_batch_size: [16, 32]
   max_queue_delay_microseconds: 500
 }

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -337,6 +337,12 @@ void AutofillConfig(TritonJson::Value &config, const std::vector<IOConfig> &mode
   } else {
     config.AddInt("max_batch_size", model_max_batch_size);
   }
+
+  if (!config.Find("dynamic_batching")) {
+    TritonJson::Value dyn_batching(config, TritonJson::ValueType::OBJECT);
+    // we add an empty object and rely on Triton server filling it with default values
+    config.Add("dynamic_batching", std::move(dyn_batching));
+  }
 }
 
 

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -462,7 +462,8 @@ TEST_CASE("Autofill config") {
             ]
         }
     ],
-    "max_batch_size": 13
+    "max_batch_size": 13,
+    "dynamic_batching": {}
 })json";
 
   AutofillConfig(config, model_ins, model_outs, 13);


### PR DESCRIPTION
This PR extends auto-config to automatically enable dynamic batching in DALI models

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>