### PR TITLE
Set python version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
-set(PYTHON_VERSION "3.10" STRING
-    "Python version, which will be used to create conda environment for DALI")
+set(PYTHON_VERSION "3.10" CACHE STRING
+    "Python version, which will be used to create conda environment for DALI.")
 
 set(DALI_VERSION "" CACHE STRING
     "DALI version that should be downloaded by the build system.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ set(TRITON_COMMON_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for t
 set(TRITON_CORE_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for triton-inference-server/backend repo")
 
+set(PYTHON_VERSION "3.10" STRING
+    "Python version, which will be used to create conda environment for DALI")
+
 set(DALI_VERSION "" CACHE STRING
     "DALI version that should be downloaded by the build system.
     By default the latest available DALI version will be downloaded.

--- a/cmake/dalienv.yml.in
+++ b/cmake/dalienv.yml.in
@@ -1,6 +1,6 @@
 name: dalienv
 dependencies:
-  - python=3.8
+  - python=@PYTHON_VERSION@
   - pip
   - pip:
       - --extra-index-url @DALI_EXTRA_INDEX_URL@

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -89,7 +89,6 @@ ARG DALI_DOWNLOAD_VERSION
 ARG DALI_DOWNLOAD_EXTRA_OPTIONS
 
 COPY . .
-
 ARG TRITON_BACKEND_API_VERSION="r22.07"
 
 RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                                 \

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -50,8 +50,8 @@ add_custom_command(
 if(${TRITON_DALI_SKIP_DOWNLOAD})
     get_dali_paths(DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
 else()
-    set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python3.8/site-packages/nvidia/dali/include)
-    set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python3.8/site-packages/nvidia/dali)
+    set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali/include)
+    set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali)
     set(DALI_LIBRARIES dali dali_core dali_kernels dali_operators)
 endif()  # TRITON_DALI_SKIP_DOWNLOAD
 


### PR DESCRIPTION
This PR updates the Python version used for creating conda environment for DALI to `3.10`. Additionally, extracts hardcoded values to a variable, so its easier in the future.

Signed-off-by: szalpal <mszolucha@nvidia.com>