### PR TITLE
Update conda env packages during the creation

### DIFF
--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -42,7 +42,7 @@ configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml 
 add_custom_command(
     OUTPUT dali_env
     COMMAND
-        conda env create -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --force -q
+        conda env create -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --force -q && conda env update -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv -q
     COMMAND touch dali_env  # So that this command won't be re-run every time
     COMMENT "Building DALI conda environment."
 )


### PR DESCRIPTION
- when the conda environment is created it first uses
  the existing packages in the system - for example
  the one installed from Miniconda3-py38_4.12.0-Linux-x86_64.sh,
  which may become outdated and vulnerable sooner or later.
  This PR makes the environment to use the latest available
  necessary packages when created to fix all CVEs that are fixable
  by the update of the conda environment

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>