### PR TITLE
 Use conda-forge channel when updating conda environment

### DIFF
--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -42,7 +42,7 @@ configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml 
 add_custom_command(
     OUTPUT dali_env
     COMMAND
-        conda env create -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --force -q && conda env update -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv -q
+        conda env create -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --force -q && conda update -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --all -c conda-forge -y -q
     COMMAND touch dali_env  # So that this command won't be re-run every time
     COMMENT "Building DALI conda environment."
 )


### PR DESCRIPTION
- https://github.com/triton-inference-server/dali_backend/pull/166
   added the update step for the created conda environment, however,
   it uses the default conda channel which has outdated packages.
   In this PR we move to conda-forge with the most up to date packages

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>