### PR TITLE
Add ProtoBuf txt parsing to read max_batch_size

### DIFF
--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -384,24 +384,11 @@ void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> &out_c
 }
 
 
-int ReadMaxBatchSize(TritonJson::Value &config) {
-  int64_t bs = -1;
-  TritonError{config.MemberAsInt("max_batch_size", &bs)};  // immediately release error
-  if (bs > std::numeric_limits<int>::max() || bs < -1) {
-    throw TritonError::InvalidArg(
-      make_string("Invalid value of max_batch_size in model configuration: ", bs));
-  }
-  if (bs > 0) {
-    return static_cast<int>(bs);
-  } else {
-    return -1;
-  }
-}
-
-
 void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_configs,
                     const std::vector<IOConfig> &out_configs) {
-  if (ReadMaxBatchSize(config) < 1) {
+  int64_t bs = -1;
+  TritonError{config.MemberAsInt("max_batch_size", &bs)};  // immediately release error
+  if (bs < 1) {
     throw TritonError::InvalidArg("Missing max_batch_size field in model configuration.");
   }
 

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -421,4 +421,121 @@ void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_c
   }
   ValidateOutputs(outputs, out_configs);
 }
+
+
+bool is_whitespace(char c) {
+  return std::isspace(static_cast<unsigned char>(c));
+}
+
+
+bool is_sep(char c) {
+  return c == ';' || c == ',';
+}
+
+
+void skip_whitespace(std::string_view &text) {
+  size_t i = 0;
+  while (i < text.size() && is_whitespace(text[i])) ++i;
+  text.remove_prefix(i);
+}
+
+
+void skip_line(std::string_view &text) {
+  auto pos = text.find('\n');
+  if (pos == text.npos) {
+    text = std::string_view();
+  } else {
+    text.remove_prefix(pos+1);
+  }
+}
+
+
+void skip_ignored(std::string_view &text) {
+  skip_whitespace(text);
+  while (!text.empty() && text[0] == '#') {
+    skip_line(text); // remove comment
+    skip_whitespace(text);
+  }
+}
+
+
+void skip_string(std::string_view &text) {
+  // in loop, because string can consist of multiple literals
+  while (!text.empty() && text[0] == '\"') {
+    size_t end = 1;
+    while (end < text.size() && text[end] != '\"') {
+      if (text[end] == '\\') ++end; // escaped character
+      ++end;
+    }
+    text.remove_prefix(end + 1);
+    skip_ignored(text);
+  }
+}
+
+
+void skip_complex(std::string_view &text, char bra, char ket) {
+  if (text.empty()) return;
+  size_t open_bracket = 0;
+  do {
+    if (text[0] == '\"') {
+      skip_string(text);
+    } else {
+      if (text[0] == bra) ++open_bracket;
+      else if (text[0] == ket) --open_bracket;
+      text.remove_prefix(1);
+    }
+    skip_ignored(text);
+  } while (!text.empty() && open_bracket > 0);
+}
+
+
+std::optional<int64_t> parse_int(std::string_view &text) {
+  skip_ignored(text);
+  if (text.empty()) return {};
+  bool negative = false;
+  if (text[0] == '-') {
+    negative = true;
+    text.remove_prefix(1);
+    skip_ignored(text);
+  }
+  size_t end = 0;
+  while (end < text.size() && !(is_whitespace(text[end]) || is_sep(text[end]))) ++end;
+  try {
+    std::string value(text.substr(0, end));
+    int64_t v = std::stoll(value, nullptr, 0);
+    return (negative) ? -v : v;
+  } catch (std::logic_error &err) {
+    return {};
+  }
+}
+
+
+std::optional<int64_t> ReadMBSFromPBtxt(std::string_view pb_txt) {
+  static const std::string field_name = "max_batch_size";
+  skip_ignored(pb_txt);
+  while (pb_txt.size() > field_name.size()) {
+    if (pb_txt.substr(0, field_name.size()) == field_name) {
+      pb_txt.remove_prefix(field_name.size());
+      skip_ignored(pb_txt);
+      if (pb_txt[0] == ':') {
+        pb_txt.remove_prefix(1); // remove :
+        return parse_int(pb_txt);
+      } else {
+        // scalar field name has to be followed by a colon
+        return {};
+      }
+    } else if (pb_txt[0] == '[') {
+      skip_complex(pb_txt, '[', ']');
+    } else if (pb_txt[0] == '{') {
+      skip_complex(pb_txt, '{', '}');
+    } else if (pb_txt[0] == '\"') {
+      skip_string(pb_txt);
+    } else {
+      pb_txt.remove_prefix(1);
+    }
+    skip_ignored(pb_txt);
+  }
+  return {};
+}
+
 }}}  // namespace triton::backend::dali

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -178,7 +178,7 @@ void ValidateInputs(TritonJson::Value &ins, const std::vector<IOConfig> &in_conf
 
 
 /**
- * @brief Validate the model max batch size and inputs and outputs configs against provided values.
+ * @brief Validate the model max batch size, inputs and outputs configs against provided values.
  */
 void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_configs,
                     const std::vector<IOConfig> &out_configs);
@@ -187,7 +187,7 @@ void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_c
 /**
  * @brief Read max_batch_size set in a config represented as protocol buffer text format
  * Returns a max_batch_size value or an empty optional when
- * the is absent or cannot me parsed as int
+ * the field is absent or cannot be parsed as int
  */
 std::optional<int64_t> ReadMBSFromPBtxt(std::string_view pb_txt);
 

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -189,6 +189,14 @@ int ReadMaxBatchSize(TritonJson::Value &config);
 void ValidateConfig(TritonJson::Value &config, const std::vector<IOConfig> &in_configs,
                     const std::vector<IOConfig> &out_configs);
 
+
+/**
+ * @brief Read max_batch_size set in a config represented as protocol buffer text format
+ * Returns a max_batch_size value or an empty optional when
+ * the is absent or cannot me parsed as int
+ */
+std::optional<int64_t> ReadMBSFromPBtxt(std::string_view pb_txt);
+
 }}} // namespace triton::backend::dali
 
 #endif  // DALI_BACKEND_CONFIG_TOOLS_CONFIG_TOOLS_H_

--- a/src/config_tools/config_tools.h
+++ b/src/config_tools/config_tools.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -175,12 +175,6 @@ void ValidateOutputs(TritonJson::Value &outs, const std::vector<IOConfig> &out_c
  * Names of the inputs in the config file must match the names of the inputs in the pipeline.
  */
 void ValidateInputs(TritonJson::Value &ins, const std::vector<IOConfig> &in_configs);
-
-
-/**
- * @brief Read max_batch_size field from the config. Return -1 if the field is missing.
- */
-int ReadMaxBatchSize(TritonJson::Value &config);
 
 
 /**

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -470,63 +470,6 @@ TEST_CASE("Autofill config") {
   common::TritonJson::WriteBuffer buffer;
   config.PrettyWrite(&buffer);
   REQUIRE(buffer.Contents() == expected_config);
-}
-
-
-TEST_CASE("Read max_batch_size") {
-  SECTION("correct bs") {
-    TritonJson::Value config(TritonJson::ValueType::OBJECT);
-    TRITON_CALL(config.Parse(R"json({
-    "max_batch_size": 32,
-
-    "output": [
-      {
-        "name": "o1",
-        "dims": [3, 2, 3],
-        "data_type": "TYPE_FP32"
-      },
-      {
-        "name": "o2",
-        "dims": [5, 5]
-      }
-    ]
-    })json"));
-
-    REQUIRE(ReadMaxBatchSize(config) == 32);
-  }
-
-  SECTION("incorrect bs") {
-    TritonJson::Value config(TritonJson::ValueType::OBJECT);
-    TRITON_CALL(config.Parse(R"json({
-    "max_batch_size": -2,
-    "input": [
-      {
-        "name": "i1",
-        "dims": [3, 2, 3],
-        "data_type": "TYPE_FP32",
-        "allow_ragged_batch": true
-      },
-      {
-        "name": "i2",
-        "dims": [5, 5]
-      }
-    ],
-    "output": [
-      {
-        "name": "o1",
-        "dims": [3, 2, 3],
-        "data_type": "TYPE_FP32"
-      },
-      {
-        "name": "o2",
-        "dims": [5, 5]
-      }
-    ]
-    })json"));
-
-    REQUIRE_THROWS_WITH(ReadMaxBatchSize(config),
-                        Contains("Invalid value of max_batch_size in model configuration: -2"));
-  }
 }
 
 

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -591,7 +591,7 @@ TEST_CASE("Read MBS from pb txt") {
       some_list [{f: 12}, {f: 12}, {f: 12}],
       message {string_field: "max_batch_size: 14", max_batch_size: 15;
       msg_field: {max_batch_size: 17},
-      another_string_field: "multiple literals" #interruption
+      another_string_field: "{multiple literals" #interruption
        "with \"quote\""}
       max_batch_size #interruption
       : 12;
@@ -607,7 +607,7 @@ TEST_CASE("Read MBS from pb txt") {
       max_batch_size: - # interruption
       12 message {string_field: "max_batch_size: 14", max_batch_size: 15;
       msg_field: {max_batch_size: 17},
-      another_string_field: "multiple literals" #interruption
+      another_string_field: "multiple literals}" #interruption {}}
        "with \"quote\""}
     )");
 
@@ -620,7 +620,7 @@ TEST_CASE("Read MBS from pb txt") {
       some_list [{f: 12}, {f: 12}, {f: 12}]
       message {string_field: "max_batch_size: 14", max_batch_size: 15;
       msg_field: {max_batch_size: 17},
-      another_string_field: "multiple literals" #interruption
+      another_string_field: "multiple literals" #interruption }
        "with \"quote\""}
     )");
 

--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -117,7 +117,7 @@ class DaliModel : public ::triton::backend::BackendModel {
       std::stringstream config_buffer;
       config_buffer << config_file.rdbuf();
       auto config_text = config_buffer.str();
-      config_max_batch_size_ = ReadMBSFromPBtxt(config_text).value_or(-1);
+      config_max_batch_size_ = ReadMBSFromPBtxt(config_text);
     }
 
     std::string model_path = make_string(model_repo_path, sep, version_, sep);
@@ -271,7 +271,7 @@ class DaliModel : public ::triton::backend::BackendModel {
   }
 
   void ReadPipelineProperties() {
-    auto pipeline = InstantiateDaliPipeline(config_max_batch_size_);
+    auto pipeline = InstantiateDaliPipeline(config_max_batch_size_.value_or(-1));
     auto input_names = pipeline.ListInputs();
     pipeline_inputs_.resize(input_names.size());
     for (size_t i = 0; i < input_names.size(); ++i) {
@@ -313,7 +313,7 @@ class DaliModel : public ::triton::backend::BackendModel {
   std::vector<IOConfig> pipeline_inputs_{};
   std::vector<IOConfig> pipeline_outputs_{};
   int pipeline_max_batch_size_ = -1;
-  int config_max_batch_size_ = -1;
+  std::optional<int> config_max_batch_size_ = {};
   const std::string fallback_model_filename_ = "dali.py";
   bool should_auto_complete_config_ = false;
 };

--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -111,10 +111,6 @@ class DaliModel : public ::triton::backend::BackendModel {
     TRITON_CALL(
         TRITONBACKEND_ModelRepository(triton_model_, &artifact_type, &model_repo_path));
 
-    // std::stringstream model_path_ss;
-    // model_path_ss << model_repo_path << sep << version_ << sep;
-    std::string model_path = make_string(model_repo_path, sep, version_, sep);
-
     std::string config_path = make_string(model_repo_path, sep, "config.pbtxt");
     std::ifstream config_file(config_path);
     if (config_file.good()) {
@@ -123,6 +119,8 @@ class DaliModel : public ::triton::backend::BackendModel {
       auto config_text = config_buffer.str();
       config_max_batch_size_ = ReadMBSFromPBtxt(config_text).value_or(-1);
     }
+
+    std::string model_path = make_string(model_repo_path, sep, version_, sep);
 
     std::stringstream default_model, fallback_model;
     default_model << model_path << GetModelFilename();
@@ -273,8 +271,7 @@ class DaliModel : public ::triton::backend::BackendModel {
   }
 
   void ReadPipelineProperties() {
-    int config_max_batch_size = ReadMaxBatchSize(model_config_);
-    auto pipeline = InstantiateDaliPipeline(config_max_batch_size);
+    auto pipeline = InstantiateDaliPipeline(config_max_batch_size_);
     auto input_names = pipeline.ListInputs();
     pipeline_inputs_.resize(input_names.size());
     for (size_t i = 0; i < input_names.size(); ++i) {


### PR DESCRIPTION
When config is read by the tritonserver, there is no way to determine if max_batch_size was set to 0 by the user or was it just not provided. 
To workaround it, I manually load the config text file (if it exists) and parse it (to a limited level) to read the max_batch_size field. 

Signed-off-by: Rafal <rbanas@nvidia.com>