### PR TITLE
Fix tmp filename generation

### DIFF
--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -157,7 +157,7 @@ class DaliModel : public ::triton::backend::BackendModel {
    */
   void LoadModel(std::string default_model_filename, std::string fallback_model_filename) {
     std::string& model_filename = default_model_filename;
-    std::string target = make_string("/tmp/serialized.model.", tmpname(), ".dali");
+    std::string target = tmp_model_file();
     bool load_succeeded = false;
 
     // Try to load model from the default location

--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -157,7 +157,7 @@ class DaliModel : public ::triton::backend::BackendModel {
    */
   void LoadModel(std::string default_model_filename, std::string fallback_model_filename) {
     std::string& model_filename = default_model_filename;
-    std::string target = make_string("/tmp/serialized.model.", timestamp(), ".dali");
+    std::string target = make_string("/tmp/serialized.model.", tmpname(), ".dali");
     bool load_succeeded = false;
 
     // Try to load model from the default location

--- a/src/error_handling.h
+++ b/src/error_handling.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 NVIDIA CORPORATION
+// Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,8 @@
 #include <cassert>
 #include <stdexcept>
 #include <string>
+
+#include "dali_executor/utils/dali.h"
 
 namespace triton { namespace backend { namespace dali {
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 #ifndef DALI_BACKEND_UTILS_UTILS_H_
 #define DALI_BACKEND_UTILS_UTILS_H_
 
-#include <ctime>
+#include <chrono>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -88,11 +88,8 @@ std::string vec_to_string(const std::vector<T> &vec, const std::string &lbracket
 
 
 inline std::string timestamp() {
-  std::time_t t = std::time(nullptr);
-  std::tm tm = *std::localtime(&t);
-  std::stringstream timestamp;
-  timestamp << std::put_time(&tm, "%Y%m%d_%H%M%S");
-  return timestamp.str();
+  auto timestamp = std::chrono::steady_clock::now();
+  return std::to_string(timestamp.time_since_epoch().count());
 }
 
 }}}  // namespace triton::backend::dali

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -88,9 +88,12 @@ std::string vec_to_string(const std::vector<T> &vec, const std::string &lbracket
 }
 
 
-inline std::string tmpname() {
-  static std::atomic<int64_t> ts{std::chrono::steady_clock::now().time_since_epoch().count()};
-  return std::to_string(ts++);
+inline std::string tmp_model_file() {
+  char templat[] = "/tmp/serialized.modelXXXXXX";
+  int fd = mkstemp(templat);
+  ENFORCE(fd != -1, "Could not create a temporary file for pipeline auto-serialization.");
+  close(fd);
+  return std::string(templat);
 }
 
 }}}  // namespace triton::backend::dali

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <vector>
 #include <iomanip>
+#include <atomic>
 
 namespace triton { namespace backend { namespace dali {
 
@@ -87,9 +88,9 @@ std::string vec_to_string(const std::vector<T> &vec, const std::string &lbracket
 }
 
 
-inline std::string timestamp() {
-  auto timestamp = std::chrono::steady_clock::now();
-  return std::to_string(timestamp.time_since_epoch().count());
+inline std::string tmpname() {
+  static std::atomic<int64_t> ts{std::chrono::steady_clock::now().time_since_epoch().count()};
+  return std::to_string(ts++);
 }
 
 }}}  // namespace triton::backend::dali

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -23,12 +23,15 @@
 #ifndef DALI_BACKEND_UTILS_UTILS_H_
 #define DALI_BACKEND_UTILS_UTILS_H_
 
-#include <chrono>
 #include <string>
 #include <sstream>
 #include <vector>
 #include <iomanip>
-#include <atomic>
+
+#include <unistd.h>
+
+#include "src/error_handling.h"
+
 
 namespace triton { namespace backend { namespace dali {
 


### PR DESCRIPTION
Autoserialize was not working correctly due to race condition in tmp file naming. It was using a timestamp with a resolution of a second which caused conflicts between models.

To fix this, I changed the timestamp to maximal resolution of a monotonic clock (std::steady_clock).