### PR TITLE
Add `"depleted"` operator trace handling

### DIFF
--- a/docs/examples/video_decode_remap/client.py
+++ b/docs/examples/video_decode_remap/client.py
@@ -23,9 +23,11 @@
 
 import argparse
 import os
-import sys
 import numpy as np
 import tritonclient.grpc
+from functools import partial
+import queue
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -36,14 +38,19 @@ def parse_args():
     return parser.parse_args()
 
 
-def handle_dali_result(result, error):
-    if error is not None:
-        print(error)
+class UserData:
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(usr_data, result, error):
+    if error:
+        usr_data._completed_requests.put(error)
     else:
-        # Get the output and show the result
-        output0_data = result.as_numpy("OUTPUT")
-        print(output0_data.shape)
-        # Do something with the output...
+        usr_data._completed_requests.put(result)
+
+
+user_data = UserData()
 
 
 def load_videos(filenames):
@@ -57,9 +64,9 @@ def array_from_list(arrays):
     """
     Convert list of ndarrays to single ndarray with ndims+=1. Pad if necessary.
     """
-    lengths = [arr.shape[0] for arr in arrays]
+    lengths = list(map(lambda x, arr=arrays: arr[x].shape[0], [x for x in range(len(arrays))]))
     max_len = max(lengths)
-    arrays = [np.pad(arr, (0, max_len - arr.shape[0])) for arr in arrays]
+    arrays = list(map(lambda arr, ml=max_len: np.pad(arr, (0, ml - arr.shape[0])), arrays))
     for arr in arrays:
         assert arr.shape == arrays[0].shape, "Arrays must have the same shape"
     return np.stack(arrays)
@@ -69,64 +76,66 @@ def main():
     FLAGS = parse_args()
 
     input_batch_size = 1  # `fn.inputs.video` accepts only one sample at the input,
-    max_batch_size = 3    # but the output from `fn.inputs.video` has always max_batch_size.
+    max_batch_size = 3  # but the output from `fn.inputs.video` has always max_batch_size.
 
     # Load test data
     if FLAGS.video is None:
         dali_extra_path = os.environ['DALI_EXTRA_PATH']
         filenames = [
-            os.path.join(dali_extra_path, "db", "video", "containers", "mkv", "cfr-h264.mkv"),
-            os.path.join(dali_extra_path, "db", "video", "containers", "mkv", "cfr-h265.mkv"),
+            os.path.join(dali_extra_path, "db", "video", "containers", "mkv", "cfr.mkv"),
         ]
     else:
         filenames = [os.path.join(FLAGS.video, p) for p in os.listdir(FLAGS.video)]
         filenames = filenames[:input_batch_size]
 
-    try:
-        triton_client = tritonclient.grpc.InferenceServerClient(url=FLAGS.url)
-    except Exception as e:
-        print("channel creation failed: " + str(e))
-        sys.exit(1)
+    with tritonclient.grpc.InferenceServerClient(url=FLAGS.url) as triton_client:
 
-    model_name = "model.dali"
-    model_version = -1
+        model_name = "model.dali"
+        model_version = -1
 
-    # Start stream
-    triton_client.start_stream(callback=handle_dali_result)
+        # Start stream
+        triton_client.start_stream(callback=partial(callback, user_data))
 
-    # Config output
-    outputs = []
-    output_name = "OUTPUT"
-    outputs.append(tritonclient.grpc.InferRequestedOutput(output_name))
+        # Config output
+        outputs = []
+        output_name = "OUTPUT"
+        outputs.append(tritonclient.grpc.InferRequestedOutput(output_name))
 
-    # Config input 0: video
-    video_raw = load_videos(filenames)
-    video_raw = array_from_list(video_raw)
-    input_shape = list(video_raw.shape)
-    assert input_batch_size == input_shape[0]
+        # Config input 0: video
+        video_raw = load_videos(filenames)
+        video_raw = array_from_list(video_raw)
+        input_shape = list(video_raw.shape)
+        assert input_batch_size == input_shape[0], f"{input_batch_size} == {input_shape[0]}"
 
-    # Config inputs 1 & 2: undistort (remap) maps
-    npz = np.load('./remap.npz')
-    remap_u = [npz['remap_x'] for _ in range(max_batch_size)]
-    remap_v = [npz['remap_y'] for _ in range(max_batch_size)]
-    remap_u = array_from_list(remap_u)
-    remap_v = array_from_list(remap_v)
-    map_shape = list(remap_u.shape)
+        # Config inputs 1 & 2: undistort (remap) maps
+        npz = np.load('remap.npz')
+        remap_u = [npz['remap_x'] for _ in range(max_batch_size)]
+        remap_v = [npz['remap_y'] for _ in range(max_batch_size)]
+        remap_u = array_from_list(remap_u)
+        remap_v = array_from_list(remap_v)
+        map_shape = list(remap_u.shape)
 
-    # Initialize tritonserver inputs
-    inputs = [
-        tritonclient.grpc.InferInput("INPUT", input_shape, "UINT8"),
-        tritonclient.grpc.InferInput("MAPX", map_shape, "FP32"),
-        tritonclient.grpc.InferInput("MAPY", map_shape, "FP32"),
-    ]
+        # Initialize tritonserver inputs
+        inputs = [
+            tritonclient.grpc.InferInput("INPUT", input_shape, "UINT8"),
+            tritonclient.grpc.InferInput("MAPX", map_shape, "FP32"),
+            tritonclient.grpc.InferInput("MAPY", map_shape, "FP32"),
+        ]
 
-    inputs[0].set_data_from_numpy(video_raw)
-    inputs[1].set_data_from_numpy(remap_u)
-    inputs[2].set_data_from_numpy(remap_v)
+        inputs[0].set_data_from_numpy(video_raw)
+        inputs[1].set_data_from_numpy(remap_u)
+        inputs[2].set_data_from_numpy(remap_v)
 
-    request_id = "0"
-    triton_client.async_stream_infer(model_name=model_name, inputs=inputs, request_id=request_id,
-                                     outputs=outputs)
+        request_id = "0"
+        triton_client.async_stream_infer(model_name=model_name, inputs=inputs, request_id=request_id,
+                                         outputs=outputs)
+
+        data_item = user_data._completed_requests.get()
+        output0_data = data_item.as_numpy("OUTPUT")
+        print(output0_data.shape)
+        data_item = user_data._completed_requests.get()
+        output0_data = data_item.as_numpy("OUTPUT")
+        print(output0_data.shape)
 
 
 if __name__ == '__main__':

--- a/docs/examples/video_decode_remap/model_repository/model.dali/1/dali.py
+++ b/docs/examples/video_decode_remap/model_repository/model.dali/1/dali.py
@@ -48,8 +48,8 @@ def pipeline():
     vid = fn.resize(vid, resize_x=OUT_WIDTH, resize_y=OUT_HEIGHT)
 
     # Remove distortion.
-    mapx = fn.external_source(name="MAPX", ndim=2, dtype=dali.types.FLOAT).gpu()
-    mapy = fn.external_source(name="MAPY", ndim=2, dtype=dali.types.FLOAT).gpu()
+    mapx = fn.external_source(name="MAPX", ndim=2, dtype=dali.types.FLOAT, repeat_last=True).gpu()
+    mapy = fn.external_source(name="MAPY", ndim=2, dtype=dali.types.FLOAT, repeat_last=True).gpu()
     # Provided camera maps assume, that the (0,0) point is in the center of the image.
     # Therefore, we have to modify them to have the origin in the top-left corner.
     mapx = mapx - OUT_WIDTH * 0.5

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -47,7 +47,7 @@ void DaliExecutor::SetupInputs(const std::vector<IDescr>& inputs) {
   request_id_++;
   for (auto& inp : c_inputs) {
     input_names_.push_back(inp.meta.name);
-    pipeline_.SetInput(inp, {request_id_str});
+    pipeline_.SetInput(inp, {request_id_.str()});
   }
 }
 

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -144,8 +144,8 @@ bool DaliExecutor::IsInputConsumed() {
   for (auto &name : input_names_) {
     auto trace = pipeline_.TryGetOperatorTrace(name, "depleted");
     if (!trace.has_value()) {
-      throw std::runtime_error("DALI Error: 'depleted' trace shall be available for every input operator.");
-      throw std::logic_error(make_string("DALI internal error: \"depleted\" trace not found for input \"" , name ,"\". It must be defined by all input operators."));
+      throw std::logic_error(make_string("DALI internal error: \"depleted\" trace not found for input \"" ,
+                                         name ,"\". It must be defined by all input operators."));
     }
     if (streq(trace->c_str(), "true")) {
       return true;

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -44,8 +44,7 @@ void DaliExecutor::SetupInputs(const std::vector<IDescr>& inputs) {
   }
   WaitForCopies();
   input_names_.clear();
-  request_id_ += 1;
-  std::string request_id_str = std::to_string(request_id_);
+  request_id_++;
   for (auto& inp : c_inputs) {
     input_names_.push_back(inp.meta.name);
     pipeline_.SetInput(inp, {request_id_str});

--- a/src/dali_executor/dali_executor.cc
+++ b/src/dali_executor/dali_executor.cc
@@ -145,6 +145,7 @@ bool DaliExecutor::IsInputConsumed() {
     auto trace = pipeline_.TryGetOperatorTrace(name, "depleted");
     if (!trace.has_value()) {
       throw std::runtime_error("DALI Error: 'depleted' trace shall be available for every input operator.");
+      throw std::logic_error(make_string("DALI internal error: \"depleted\" trace not found for input \"" , name ,"\". It must be defined by all input operators."));
     }
     if (streq(trace->c_str(), "true")) {
       return true;
@@ -152,7 +153,7 @@ bool DaliExecutor::IsInputConsumed() {
   }
   for (auto &name : input_names_) {
     auto trace = pipeline_.TryGetOperatorTrace(name, "next_output_data_id");
-    if (trace.has_value() && std::stoull(*trace) != request_id_) {
+    if (trace.has_value() && *trace != request_id_.str()) {
       return true;
     }
   }

--- a/src/dali_executor/dali_executor.h
+++ b/src/dali_executor/dali_executor.h
@@ -106,6 +106,16 @@ class DaliExecutor {
    */
   IOBufferI* GetOutputBuffer(const std::string& name, device_type_t device);
 
+  /**
+   * @brief Checks if current input has been consumed by current iteration.
+   *
+   * When input has been consumed, the Backend shall wrap up current request. Also, it is necessary to provide
+   * data with the next request for the next DALI iteration.
+   *
+   * @return True, if input has been consumed.
+   */
+  bool IsInputConsumed();
+
   DaliPipeline pipeline_;
   ThreadPool thread_pool_;
   std::map<std::string, IOBuffer<CPU>> cpu_buffers_;

--- a/src/dali_executor/dali_executor.h
+++ b/src/dali_executor/dali_executor.h
@@ -30,8 +30,9 @@
 #include "src/dali_executor/dali_pipeline.h"
 #include "src/dali_executor/io_buffer.h"
 #include "src/dali_executor/io_descriptor.h"
+#include "src/dali_executor/request_id.h"
 
-namespace triton { namespace backend { namespace dali {
+namespace triton::backend::dali {
 
 
 struct OutputInfo {
@@ -122,9 +123,9 @@ class DaliExecutor {
   std::map<std::string, IOBuffer<GPU>> gpu_buffers_;
   bool inputs_consumed_ = true;
   std::vector<std::string> input_names_;
-  uint64_t request_id_ = 0;
+  RequestId<uint64_t> request_id_;
 };
 
-}}}  // namespace triton::backend::dali
+}  // namespace triton::backend::dali
 
 #endif  // DALI_BACKEND_DALI_EXECUTOR_DALI_EXECUTOR_H_

--- a/src/dali_executor/request_id.h
+++ b/src/dali_executor/request_id.h
@@ -1,0 +1,66 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef DALI_BACKEND_DALI_EXECUTOR_REQUEST_ID_H_
+#define DALI_BACKEND_DALI_EXECUTOR_REQUEST_ID_H_
+
+#include <string>
+
+namespace triton::backend::dali {
+
+template<typename T = uint64_t>
+struct RequestId {
+  /**
+   * Prefix increment.
+   */
+  T& operator++() {
+    request_id_str_ = std::to_string(++request_id_);
+    return request_id_;
+  }
+
+
+  /**
+   * Postfix increment.
+   */
+  T operator++(int) {
+    T old = request_id_;
+    operator++();
+    return old;
+  }
+
+
+  /**
+   * Return request_id_ as a string.
+   */
+  const std::string& str() const {
+    return request_id_str_;
+  }
+
+
+ private:
+  T request_id_ = 0;
+  std::string request_id_str_ = std::to_string(request_id_);
+};
+
+}  // namespace triton::backend::dali
+
+#endif  // DALI_BACKEND_DALI_EXECUTOR_REQUEST_ID_H_


### PR DESCRIPTION
- [x] Wait for DALI 1.26 release

This PR duplicates #187 .

Should the VideoInput operator be properly working with ExternalSource in the same pipeline, DALI Backend needs to properly handle the "depleted" operator trace. This trace, defined in DALI, specifies when a given operator needs more data at the input. Refers to https://github.com/NVIDIA/DALI/pull/4794