### PR TITLE
Fix compilation with gcc 11.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif ()  # TRITON_ENABLE_GPU
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-local-typedefs")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-unused-function -Wno-unused-local-typedefs -Wno-free-nonheap-object")
 
 set(DALI_DOWNLOAD_PKG_NAME "nvidia-dali-cuda${CUDAToolkit_VERSION_MAJOR}0" CACHE STRING
         "DALI pip package name to download.

--- a/src/dali_model.h
+++ b/src/dali_model.h
@@ -265,7 +265,7 @@ class DaliModel : public ::triton::backend::BackendModel {
         if (kind_str == "KIND_GPU") {
           triton::common::TritonJson::Value dev_array;
           if (inst_group.Find("gpus", &dev_array) && dev_array.ArraySize() > 0) {
-            int64_t dev_id;
+            int64_t dev_id = CPU_ONLY_DEVICE_ID;
             dev_array.IndexAsInt(0, &dev_id);
             return dev_id;
           }


### PR DESCRIPTION
- updates Catch2 to 2.13.9
- adds -Wno-free-nonheap-object compilation flag
  as the compiler gets confused with SmallVector
  memory management
- initializes dev_id variable