### PR TITLE
Working around incompatiblitiy in CUDA compat layer

### DIFF
--- a/benchmarks/BM_efficientnet/run-benchmarks.sh
+++ b/benchmarks/BM_efficientnet/run-benchmarks.sh
@@ -52,9 +52,9 @@ done
 #BATCH_SIZES=(1 2 4 8 16 32 64)
 
 CONCURRENCY_RANGE=${CONCURRENCY_RANGE:-"16:512:16"}
-GRPC_ADDRESS=${GRPC_ADDR:-"localhost:8001"}
+GRPC_ADDR=${GRPC_ADDR:-"localhost:8001"}
 TIME_WINDOW=10000
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDRESS -p$TIME_WINDOW --verbose-csv --collect-metrics"
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW --verbose-csv --collect-metrics"
 INPUT_NAME="INPUT"
 BENCH_DIR="bench-$(date +%Y%m%d_%H%M%S)"
 

--- a/docs/examples/efficientnet/setup.sh
+++ b/docs/examples/efficientnet/setup.sh
@@ -41,13 +41,12 @@ RANDOM_STRING=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13 ; echo '')
 echo "Random container name: $RANDOM_STRING"
 
 docker build -t convnets -f Dockerfile.bench .
-docker run -di --shm-size 8g --gpus all --name $RANDOM_STRING convnets
-docker exec -i $RANDOM_STRING python deploy_on_triton.py --model-name efficientnet-b0 --model-repository /model_repository --batch-size "$1"
+docker run --shm-size 8g --gpus all --name $RANDOM_STRING convnets python deploy_on_triton.py --model-name efficientnet-b0 --model-repository /model_repository --batch-size "$1"
 
 popd || exit 1
 
 docker cp $RANDOM_STRING:/model_repository ./
-docker kill $RANDOM_STRING
+docker rm $RANDOM_STRING
 
 # Set max_batch_size in the remaining models
 insert_batch_size () {


### PR DESCRIPTION
When running the `setup.sh` script using CUDA compat layer, `docker exec` proves to be problematic. It is better not to use `docker exec`, but to run `docker run` and then copy out the artifacts from the container.