### PR TITLE
Fix building DALI with `TRITON_DALI_SKIP_DOWNLOAD=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ message(STATUS "Build configuration: " ${CMAKE_BUILD_TYPE})
 # projects included in this one by FetchContent.
 #
 option(TRITON_DALI_SKIP_DOWNLOAD "Don't download DALI. Use the version provided in the system" OFF)
+option(TRITON_DALI_BUILD_IN_TRITON "Turn this option on, if the DALI Backend is built inside Triton docker container." OFF)
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 option(WERROR "Trigger error on warnings" OFF)

--- a/cmake/dali.cmake
+++ b/cmake/dali.cmake
@@ -20,10 +20,10 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Using DALI's installed whl, find the location of DALI libs and DALI include dirs
-function(get_dali_paths DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
+function(get_dali_paths CONDA_ENV_PREFIX DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
 
     execute_process(
-            COMMAND python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir())"
+            COMMAND ${CONDA_ENV_PREFIX}/bin/python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir())"
             OUTPUT_VARIABLE DALI_INCLUDE_DIR
             RESULT_VARIABLE INCLUDE_DIR_RESULT)
     string(STRIP ${DALI_INCLUDE_DIR} DALI_INCLUDE_DIR)
@@ -33,7 +33,7 @@ function(get_dali_paths DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR
     endif ()
 
     execute_process(
-            COMMAND python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir())"
+            COMMAND ${CONDA_ENV_PREFIX}/bin/python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir())"
             OUTPUT_VARIABLE DALI_LIB_DIR
             RESULT_VARIABLE LIB_DIR_RESULT)
     string(STRIP ${DALI_LIB_DIR} DALI_LIB_DIR)

--- a/cmake/dali.cmake
+++ b/cmake/dali.cmake
@@ -20,27 +20,29 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Using DALI's installed whl, find the location of DALI libs and DALI include dirs
-function(get_dali_paths CONDA_ENV_PREFIX DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
+function(get_dali_paths PYTHON_BINARY DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
 
     execute_process(
-            COMMAND ${CONDA_ENV_PREFIX}/bin/python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir())"
+            COMMAND ${PYTHON_BINARY} -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir())"
             OUTPUT_VARIABLE DALI_INCLUDE_DIR
             RESULT_VARIABLE INCLUDE_DIR_RESULT)
-    string(STRIP ${DALI_INCLUDE_DIR} DALI_INCLUDE_DIR)
 
     if (${INCLUDE_DIR_RESULT} EQUAL "1")
         message(FATAL_ERROR "Failed to get include paths for DALI. Make sure that DALI is installed.")
     endif ()
 
+    string(STRIP ${DALI_INCLUDE_DIR} DALI_INCLUDE_DIR)
+
     execute_process(
-            COMMAND ${CONDA_ENV_PREFIX}/bin/python3 -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir())"
+            COMMAND ${PYTHON_BINARY} -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir())"
             OUTPUT_VARIABLE DALI_LIB_DIR
             RESULT_VARIABLE LIB_DIR_RESULT)
-    string(STRIP ${DALI_LIB_DIR} DALI_LIB_DIR)
 
     if (${LIB_DIR_RESULT} EQUAL "1")
         message(FATAL_ERROR "Failed to get library paths for DALI. Make sure that DALI is installed.")
     endif ()
+
+    string(STRIP ${DALI_LIB_DIR} DALI_LIB_DIR)
 
     set(${DALI_INCLUDE_DIR_VAR} ${DALI_INCLUDE_DIR} PARENT_SCOPE)
     set(${DALI_LIB_DIR_VAR} ${DALI_LIB_DIR} PARENT_SCOPE)

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -101,6 +101,7 @@ RUN mkdir build_in_ci && cd build_in_ci && \
       -D CMAKE_BUILD_TYPE=Debug                                   \
       -D TRITON_BACKEND_API_VERSION=${TRITON_BACKEND_API_VERSION} \
       -D TRITON_DALI_SKIP_DOWNLOAD=ON                             \
+      -D TRITON_DALI_BUILD_IN_TRITON=ON                           \
       .. &&                                                       \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -102,6 +102,8 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
         -D DALI_EXTRA_INDEX_URL=${DALI_DOWNLOAD_EXTRA_INDEX_URL}}                     \
       -D DALI_VERSION=${DALI_DOWNLOAD_VERSION}                                        \
       -D DALI_DOWNLOAD_EXTRA_OPTIONS="${DALI_DOWNLOAD_EXTRA_OPTIONS}"                 \
+      -D TRITON_DALI_SKIP_DOWNLOAD=OFF                                                \
+      -D TRITON_DALI_BUILD_IN_TRITON=ON                                               \
       .. &&                                                                           \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -51,7 +51,11 @@ add_custom_command(
 )
 
 if(${TRITON_DALI_SKIP_DOWNLOAD})
-    get_dali_paths(${CONDA_ENV_PATH} DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
+    if(${TRITON_DALI_BUILD_IN_TRITON})
+        get_dali_paths("${CONDA_ENV_PATH}/bin/python3" DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
+    else()
+        get_dali_paths("python3" DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
+    endif()
 else()
     set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali/include)
     set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali)

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 
 configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml @ONLY)
 
+set(CONDA_ENV_PREFIX ${CMAKE_INSTALL_PREFIX}/backends/dali/conda/envs)
+set(CONDA_ENV_PATH ${CONDA_ENV_PREFIX}/dalienv)
+
 add_custom_command(
     OUTPUT dali_env
     COMMAND
@@ -48,7 +51,7 @@ add_custom_command(
 )
 
 if(${TRITON_DALI_SKIP_DOWNLOAD})
-    get_dali_paths(DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
+    get_dali_paths(${CONDA_ENV_PATH} DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
 else()
     set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali/include)
     set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali)
@@ -84,7 +87,7 @@ target_link_libraries(dali_executor PUBLIC
 
 target_compile_definitions(dali_executor PUBLIC)
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dalienv
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali/conda/envs
+    install(DIRECTORY ${CONDA_ENV_PATH}
+            DESTINATION ${CONDA_ENV_PREFIX}
             USE_SOURCE_PERMISSIONS)
 endif ()


### PR DESCRIPTION
This PR introduces a fix for building DALI Backend directly within Triton container with `-D TRITON_SKIP_DALI_DOWNLOAD=ON` option passed to the cmake.

When the aforementioned option is passed to `cmake`, `get_dali_paths` function is responsible for discovering the path of the DALI installation in the system. This function uses DALI and Python directly. In case of building within Triton container, the system-defined `python` path is not the proper one. The proper `python` path is the one created by the conda environment, which has a different path than the system-defined `python` binary. This PR allows to specify which `python` should be used inside `get_dali_paths` invocation.

From now on, when DALI is built within Triton docker container, `TRITON_DALI_BUILD_IN_TRITON` option shall be turned `ON` (it is not the default option).