### PR TITLE
Fix model counting

### DIFF
--- a/src/dali_executor/dali_pipeline.cc
+++ b/src/dali_executor/dali_pipeline.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020-2023 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,6 @@
 namespace triton { namespace backend { namespace dali {
 
 std::once_flag DaliPipeline::dali_initialized_{};
-std::atomic_int DaliPipeline::instance_counter_ = 0;
 
 
 TensorListShape<> DaliPipeline::GetOutputShapeAt(int output_idx) {

--- a/src/dali_executor/executor.test.cc
+++ b/src/dali_executor/executor.test.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2020 NVIDIA CORPORATION
+// Copyright (c) 2020-2024 NVIDIA CORPORATION
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,7 @@ void coalesced_compare(const std::vector<OBufferDescr> &obuffers,
 TEST_CASE("Scaling Pipeline") {
   std::string pipeline_s((const char *)pipelines::scale_pipeline_str,
                          pipelines::scale_pipeline_len);
-  DaliPipeline pipeline(pipeline_s, 256, 4, 0, true);
+  DaliPipeline pipeline(pipeline_s, 256, 4, 0);
   DaliExecutor executor(std::move(pipeline));
   std::mt19937 rand(1217);
   std::uniform_real_distribution<float> dist(-1.f, 1.f);
@@ -125,7 +125,7 @@ TEST_CASE("Scaling Pipeline") {
 
 TEST_CASE("RN50 pipeline") {
   std::string pipeline_s((const char *)pipelines::rn50_gpu_dali_chr, pipelines::rn50_gpu_dali_len);
-  DaliPipeline pipeline(pipeline_s, 1, 3, 0, false);
+  DaliPipeline pipeline(pipeline_s, 1, 3, 0);
   DaliExecutor executor(std::move(pipeline));
   IDescr input;
   input.meta.name = "DALI_INPUT_0";

--- a/src/dali_executor/utils/dali.h
+++ b/src/dali_executor/utils/dali.h
@@ -69,6 +69,10 @@ inline int64_t dali_type_size(dali_data_type_t type) {
     return 8;
 }
 
+inline void ReleaseUnusedMemory() {
+  daliReleaseUnusedMemory();
+}
+
 }}}  // namespace triton::backend::dali
 
 

--- a/src/dali_model.cc
+++ b/src/dali_model.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,8 @@
 #include "src/dali_model.h"
 
 namespace triton { namespace backend { namespace dali {
+
+std::atomic_int DaliModel::loaded_models_count_ = 0;
 
 TRITONSERVER_Error* DaliModel::Create(TRITONBACKEND_Model* triton_model, DaliModel** state) {
   try {

--- a/src/dali_model_instance.h
+++ b/src/dali_model_instance.h
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -62,8 +62,7 @@ class DaliModelInstance : public ::triton::backend::BackendModelInstance {
     auto max_batch_size = dali_model_->MaxBatchSize();
     if (max_batch_size < 1) max_batch_size = -1;
     auto num_threads = dali_model_->GetModelParamters().GetNumThreads();
-    DaliPipeline pipeline(serialized_pipeline, max_batch_size, num_threads, GetDaliDeviceId(),
-                          ShouldReleaseBuffersAfterUnload());
+    DaliPipeline pipeline(serialized_pipeline, max_batch_size, num_threads, GetDaliDeviceId());
     dali_executor_ = std::make_unique<DaliExecutor>(std::move(pipeline));
   }
 
@@ -109,10 +108,6 @@ class DaliModelInstance : public ::triton::backend::BackendModelInstance {
 
   int32_t GetDaliDeviceId() {
     return !CudaStream() ? CPU_ONLY_DEVICE_ID : device_id_;
-  }
-
-  bool ShouldReleaseBuffersAfterUnload() const {
-    return dali_model_->ShouldReleaseBuffersAfterUnload();
   }
 
   /**


### PR DESCRIPTION
The instance counting was bugged which caused multiple issues in CI.

Instead of just fixing it, I changed it to counting loaded models, instead of created pipelines because it better fits the semantics of release_after_unload option and might save us from unnecessary memory release, when pipelines are temporarily created and destroyed. 