### PR TITLE
Decrease stability requirements for perf_analyzer measurements

### DIFF
--- a/benchmarks/BM_efficientnet/run-benchmarks-cpu.sh
+++ b/benchmarks/BM_efficientnet/run-benchmarks-cpu.sh
@@ -49,8 +49,8 @@ done
 
 CONCURRENCY_RANGE=${CONCURRENCY_RANGE:-"16:512:16"}
 GRPC_ADDR=${GRPC_ADDR:-"localhost:8001"}
-TIME_WINDOW=10000
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW --verbose-csv --collect-metrics"
+STABILITY_PERCENTAGE=50
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -s $STABILITY_PERCENTAGE --verbose-csv --collect-metrics"
 INPUT_NAME="INPUT"
 BENCH_DIR="bench-$(date +%Y%m%d_%H%M%S)"
 

--- a/benchmarks/BM_efficientnet/run-benchmarks.sh
+++ b/benchmarks/BM_efficientnet/run-benchmarks.sh
@@ -49,8 +49,8 @@ done
 
 CONCURRENCY_RANGE=${CONCURRENCY_RANGE:-"16:512:16"}
 GRPC_ADDR=${GRPC_ADDR:-"localhost:8001"}
-TIME_WINDOW=10000
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW --verbose-csv --collect-metrics"
+STABILITY_PERCENTAGE=50
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -s $STABILITY_PERCENTAGE --verbose-csv --collect-metrics"
 INPUT_NAME="INPUT"
 BENCH_DIR="bench-$(date +%Y%m%d_%H%M%S)"
 

--- a/benchmarks/BM_resnet50/run-benchmarks.sh
+++ b/benchmarks/BM_resnet50/run-benchmarks.sh
@@ -28,10 +28,10 @@ python scripts/model-loader.py -u ${GRPC_ADDR} load -m dali
 python scripts/model-loader.py -u ${GRPC_ADDR} load -m resnet50_trt
 python scripts/model-loader.py -u ${GRPC_ADDR} load -m dali_trt_resnet50
 
-TIME_WINDOW=10000
+STABILITY_PERCENTAGE=50
 BATCH_SIZES="2 8 16 32 64 128"
 
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW"
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -s $STABILITY_PERCENTAGE"
 
 echo "WARM-UP"
 perf_analyzer $PERF_ANALYZER_ARGS -m dali_trt_resnet50 --input-data dataset.json --concurrency-range=128

--- a/qa/L0_dont_release_after_unload/test.sh
+++ b/qa/L0_dont_release_after_unload/test.sh
@@ -36,8 +36,8 @@ unload_models() {
 }
 
 GRPC_ADDR=${GRPC_ADDR:-"localhost:8001"}
-TIME_WINDOW=10000
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW --verbose-csv --collect-metrics"
+STABILITY_PERCENTAGE=50
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -s $STABILITY_PERCENTAGE --verbose-csv --collect-metrics"
 INPUT_NAME="DALI_INPUT_0"
 
 nvidia-smi -i 0

--- a/qa/L0_release_after_unload/test.sh
+++ b/qa/L0_release_after_unload/test.sh
@@ -36,8 +36,8 @@ unload_models() {
 }
 
 GRPC_ADDR=${GRPC_ADDR:-"localhost:8001"}
-TIME_WINDOW=10000
-PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -p$TIME_WINDOW --verbose-csv --collect-metrics"
+STABILITY_PERCENTAGE=50
+PERF_ANALYZER_ARGS="-i grpc -u $GRPC_ADDR -s $STABILITY_PERCENTAGE --verbose-csv --collect-metrics"
 INPUT_NAME="DALI_INPUT_0"
 
 nvidia-smi -i 0


### PR DESCRIPTION
Tests in CI that use perf_analyzer often fail because the measurements are not stable enough. This decreases that stability requirement