### PR TITLE
Remove conda package manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020 NVIDIA CORPORATION
+# Copyright (c) 2020-2024 NVIDIA CORPORATION
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -50,16 +50,16 @@ set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for 
 set(PYTHON_VERSION "3.10" CACHE STRING
     "Python version, which will be used to create conda environment for DALI.")
 
-set(DALI_VERSION "" CACHE STRING
+set(DALI_VERSION "1.20" CACHE STRING
     "DALI version that should be downloaded by the build system.
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
+set(DALI_EXTRA_INDEX_URL "http://sqrl/nvdl/datasets/dali/pip-dali" CACHE STRING
     "URL of the Index, from which DALI will be downloaded by the build system.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
+set(DALI_DOWNLOAD_EXTRA_OPTIONS "--trusted-host sqrl" CACHE STRING
     "Extra options for `pip install` call, that downloads DALI wheel.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(TRITON_BACKEND_REPO_TAG ${TRITON_BACKEND_API_VERSION} CACHE STRING "Tag for 
 set(PYTHON_VERSION "3.10" CACHE STRING
     "Python version, which will be used to create conda environment for DALI.")
 
-set(DALI_VERSION "1.20" CACHE STRING
+set(DALI_VERSION "" CACHE STRING
     "DALI version that should be downloaded by the build system.
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,11 @@ set(DALI_VERSION "" CACHE STRING
     By default the latest available DALI version will be downloaded.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_EXTRA_INDEX_URL "http://sqrl/nvdl/datasets/dali/pip-dali" CACHE STRING
+set(DALI_EXTRA_INDEX_URL "https://developer.download.nvidia.com/compute/redist" CACHE STRING
     "URL of the Index, from which DALI will be downloaded by the build system.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 
-set(DALI_DOWNLOAD_EXTRA_OPTIONS "--trusted-host sqrl" CACHE STRING
+set(DALI_DOWNLOAD_EXTRA_OPTIONS "" CACHE STRING
     "Extra options for `pip install` call, that downloads DALI wheel.
     Ignored, when TRITON_DALI_SKIP_DOWNLOAD is ON.")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -82,12 +82,11 @@ target_link_libraries(
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
         # path to the DALI backend
-        string(REGEX MATCH "dalienv/.*" DALI_NV_INSTALL_PATH ${DALI_LIB_DIR})
-        set(DALI_NV_INSTALL_PATH "$\{ORIGIN\}/conda/envs/${DALI_NV_INSTALL_PATH}")
-else(NOT ${TRITON_DALI_SKIP_DOWNLOAD})
+        set(DALI_NV_INSTALL_PATH "$\{ORIGIN\}/dali")
+else()
         # path to the predownloaded DALI instance
         set(DALI_NV_INSTALL_PATH ${DALI_LIB_DIR})
-endif(NOT ${TRITON_DALI_SKIP_DOWNLOAD})
+endif()
 
 set_target_properties(
         triton-dali-backend

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
 else()
         # path to the predownloaded DALI instance
         set(DALI_NV_INSTALL_PATH ${DALI_LIB_DIR})
-endif()
+endif(NOT ${TRITON_DALI_SKIP_DOWNLOAD})
 
 set_target_properties(
         triton-dali-backend

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2020-2022 NVIDIA CORPORATION
+# Copyright (c) 2020-2024 NVIDIA CORPORATION
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -37,23 +37,28 @@ if(DALI_VERSION)
     string(APPEND CONF_DOWNLOAD_PKG "==${DALI_VERSION}")
 endif()
 
-configure_file(${tritondalibackend_SOURCE_DIR}/cmake/dalienv.yml.in dalienv.yml @ONLY)
-
-add_custom_command(
-    OUTPUT dali_env
+add_custom_command(  # Download and unpack DALI wheel
+    OUTPUT dali_whl
     COMMAND
-        conda env create -f dalienv.yml -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --force -q && conda update -p ${CMAKE_CURRENT_BINARY_DIR}/dalienv --all -c conda-forge -y -q && curl https://patch-diff.githubusercontent.com/raw/python/cpython/pull/99421.patch | patch -d ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python3.10/ -p2 -s -t || true
-    COMMAND touch dali_env  # So that this command won't be re-run every time
-    COMMENT "Building DALI conda environment."
+        pip download ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
+          -d ${CMAKE_CURRENT_BINARY_DIR}
+          ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
+    COMMAND
+        unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
+    COMMAND
+        pip install ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
+          ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
+    COMMAND touch dali_whl  # So that this command won't be re-run every time
+    COMMENT "Acquiring DALI release"
 )
 
-if(${TRITON_DALI_SKIP_DOWNLOAD})
+if (${TRITON_DALI_SKIP_DOWNLOAD})
     get_dali_paths(DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
-else()
-    set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali/include)
-    set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dalienv/lib/python${PYTHON_VERSION}/site-packages/nvidia/dali)
+else ()
+    set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dali/nvidia/dali/include)
+    set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dali/nvidia/dali)
     set(DALI_LIBRARIES dali dali_core dali_kernels dali_operators)
-endif()  # TRITON_DALI_SKIP_DOWNLOAD
+endif ()  # TRITON_DALI_SKIP_DOWNLOAD
 
 set(DALI_INCLUDE_DIR ${DALI_INCLUDE_DIR} PARENT_SCOPE)
 set(DALI_LIB_DIR ${DALI_LIB_DIR} PARENT_SCOPE)
@@ -67,7 +72,7 @@ add_library(
         dali_executor
         STATIC
         ${DALI_BACKEND_SRCS}
-        $<$<NOT:$<BOOL:${TRITON_DALI_SKIP_DOWNLOAD}>>:dali_env>
+        $<$<NOT:$<BOOL:${TRITON_DALI_SKIP_DOWNLOAD}>>:dali_whl>
 )
 
 set_property(TARGET dali_executor PROPERTY CXX_STANDARD 17)
@@ -84,7 +89,7 @@ target_link_libraries(dali_executor PUBLIC
 
 target_compile_definitions(dali_executor PUBLIC)
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dalienv
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali/conda/envs
+    install(DIRECTORY ${DALI_LIB_DIR}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali
             USE_SOURCE_PERMISSIONS)
 endif ()


### PR DESCRIPTION
This PR removes the conda package manager from the Triton system.

Conda has been used to isolate DALI wheel (which needs to be installed apart from being unpacked in the container) from the rest of Triton packages. Since we're moving away from this requirement, DALI can be installed bare-metal inside the Triton container and conda is no longer necessary.