### PR TITLE
Change the way DALI is installed inside Triton

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -64,22 +64,6 @@ RUN CMAKE_VERSION=3.18 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /cmake-${CMAKE_BUILD}
 
-# Miniconda
-ENV PATH="/opt/conda/bin:${PATH}"
-RUN MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py38_4.12.0-Linux-x86_64.sh"; \
-    SHA256SUM="3190da6626f86eee8abf1b2fd7a5af492994eb2667357ee4243975cdbb175d7a"; \
-    wget "${MINICONDA_URL}" -O miniconda.sh -q && \
-    echo "${SHA256SUM} miniconda.sh" > shasum && \
-    sha256sum -c ./shasum && \
-    sh miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
-
 WORKDIR /dali
 
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL=https://developer.download.nvidia.com/compute/redist/nightly

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -63,23 +63,9 @@ RUN CMAKE_VERSION=3.18 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /cmake-${CMAKE_BUILD}
 
-# Miniconda
-ENV PATH="/opt/conda/bin:${PATH}"
-RUN MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-py310_24.1.2-0-Linux-x86_64.sh"; \
-    SHA256SUM="8eb5999c2f7ac6189690d95ae5ec911032fa6697ae4b34eb3235802086566d78"; \
-    wget "${MINICONDA_URL}" -O miniconda.sh -q && \
-    echo "${SHA256SUM} miniconda.sh" > shasum && \
-    sha256sum -c ./shasum && \
-    sh miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
-
 WORKDIR /dali
+
+RUN rm -rf /opt/tritonserver/backends/dali
 
 ARG DALI_DOWNLOAD_EXTRA_INDEX_URL
 ARG DALI_DOWNLOAD_PKG_NAME
@@ -104,5 +90,6 @@ RUN set -ex && mkdir build_in_ci && cd build_in_ci &&                           
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install
 
 ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:${LD_LIBRARY_PATH}
+ENV PYTHONPATH=/opt/tritonserver/backends/dali/wheel/dali
 
 WORKDIR /opt/tritonserver

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -93,3 +93,5 @@ ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:${LD_LIBRARY_PATH}
 ENV PYTHONPATH=/opt/tritonserver/backends/dali/wheel/dali
 
 WORKDIR /opt/tritonserver
+
+RUN rm -rf /dali

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,8 +79,8 @@ target_link_libraries(
 )
 
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-        # path to the DALI backend
-        set(DALI_NV_INSTALL_PATH "$\{ORIGIN\}/dali")
+        # path to the DALI shared libraries
+        set(DALI_NV_INSTALL_PATH "$\{ORIGIN\}/wheel/dali/nvidia/dali")
 else()
         # path to the predownloaded DALI instance
         set(DALI_NV_INSTALL_PATH ${DALI_LIB_DIR})

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -44,19 +44,21 @@ add_custom_command(  # Download and unpack DALI wheel
           -d ${CMAKE_CURRENT_BINARY_DIR}
           ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND
-        unzip -q -o ${CMAKE_CURRENT_BINARY_DIR}/nvidia_dali*.whl -d ${CMAKE_CURRENT_BINARY_DIR}/dali
+        /bin/bash -c "ls ${CMAKE_CURRENT_BINARY_DIR}/*.whl"  # Debug line to make sure the files are there.
     COMMAND
-        pip install ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
-          ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
+        # I've spent a whole day writing the magical line below.
+        /bin/bash -c "for file in $(ls ${CMAKE_CURRENT_BINARY_DIR}/*.whl); do unzip -q -o $file -d ${CMAKE_CURRENT_BINARY_DIR}/dali; done"
     COMMAND touch dali_whl  # So that this command won't be re-run every time
     COMMENT "Acquiring DALI release"
+    VERBATIM
 )
 
 if (${TRITON_DALI_SKIP_DOWNLOAD})
     get_dali_paths(DALI_INCLUDE_DIR DALI_LIB_DIR DALI_LIBRARIES)
 else ()
-    set(DALI_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/dali/nvidia/dali/include)
-    set(DALI_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/dali/nvidia/dali)
+    set(DALI_WHL_DIR ${CMAKE_CURRENT_BINARY_DIR}/dali)
+    set(DALI_INCLUDE_DIR ${DALI_WHL_DIR}/nvidia/dali/include)
+    set(DALI_LIB_DIR ${DALI_WHL_DIR}/nvidia/dali)
     set(DALI_LIBRARIES dali dali_core dali_kernels dali_operators)
 endif ()  # TRITON_DALI_SKIP_DOWNLOAD
 
@@ -89,7 +91,7 @@ target_link_libraries(dali_executor PUBLIC
 
 target_compile_definitions(dali_executor PUBLIC)
 if (NOT ${TRITON_DALI_SKIP_DOWNLOAD})
-    install(DIRECTORY ${DALI_LIB_DIR}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali
+    install(DIRECTORY ${DALI_WHL_DIR}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/dali/wheel
             USE_SOURCE_PERMISSIONS)
 endif ()


### PR DESCRIPTION
Due removing Conda dependency from `tritonserver` docker image, DALI Backend needs to modify how DALI wheel is installed within this docker image. We no longer can rely on `pip install` to do so - Triton's build system uses `builder` and `runtime` images. DALI Backend is built within the `builder` image and the necessary artifacts are copied to `runtime` image. Therefore DALI Backend will have the DALI wheel unpacked (and installed with CMake) together with all dependencies. Additionally, Triton's build system will set the `PYTHONPATH` variable (https://github.com/triton-inference-server/server/pull/7216), so that Python interpreter can pick proper DALI wheel.