### PR TITLE
Modify DALI wheel installation routine

### DIFF
--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -48,6 +48,8 @@ add_custom_command(  # Download and unpack DALI wheel
     COMMAND
         # I've spent a whole day writing the magical line below.
         /bin/bash -c "for file in $(ls ${CMAKE_CURRENT_BINARY_DIR}/*.whl); do unzip -q -o $file -d ${CMAKE_CURRENT_BINARY_DIR}/dali; done"
+    COMMAND
+        /bin/bash -c "for file in $(ls ${CMAKE_CURRENT_BINARY_DIR}/*.tar.gz); do tar -xzf $file -C ${CMAKE_CURRENT_BINARY_DIR}/dali; done"
     COMMAND touch dali_whl  # So that this command won't be re-run every time
     COMMENT "Acquiring DALI release"
     VERBATIM

--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -40,16 +40,9 @@ endif()
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
-        pip download ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
-          -d ${CMAKE_CURRENT_BINARY_DIR}
+        pip install ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
+          --target ${CMAKE_CURRENT_BINARY_DIR}/dali
           ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
-    COMMAND
-        /bin/bash -c "ls ${CMAKE_CURRENT_BINARY_DIR}/*.whl"  # Debug line to make sure the files are there.
-    COMMAND
-        # I've spent a whole day writing the magical line below.
-        /bin/bash -c "for file in $(ls ${CMAKE_CURRENT_BINARY_DIR}/*.whl); do unzip -q -o $file -d ${CMAKE_CURRENT_BINARY_DIR}/dali; done"
-    COMMAND
-        /bin/bash -c "for file in $(ls ${CMAKE_CURRENT_BINARY_DIR}/*.tar.gz); do tar -xzf $file -C ${CMAKE_CURRENT_BINARY_DIR}/dali; done"
     COMMAND touch dali_whl  # So that this command won't be re-run every time
     COMMENT "Acquiring DALI release"
     VERBATIM


### PR DESCRIPTION
Recently, `gast` extension (DALI dependency) changed its distribution pattern in PyPI. Previously it has beed distributed as a `whl` file, while currently it is a `tar.gz` file. Since DALI Backend approaches the DALI wheel installation in a specific way (extract + `PYTHONPATH` adjustment, instead of `pip install`), we need to augment DALI Backend build routines to accommodate for the new `gast` distribution method.