### PR TITLE
Explicitly name pipeline outputs in autoconfig tests

### DIFF
--- a/qa/L0_autoconfig/client.py
+++ b/qa/L0_autoconfig/client.py
@@ -55,7 +55,7 @@ def test_configs(url):
   dyn_batching = {
     'preferred_batch_size': [256]
   }
-  check_config(conf1['config'], 256, ['__ArithmeticGenericOp_2', '__ArithmeticGenericOp_4'], dyn_batching)
+  check_config(conf1['config'], 256, ['DALI_OUTPUT_0', 'DALI_OUTPUT_1'], dyn_batching)
 
   conf2 = client.get_model_config("partial_autoconfig", as_json=True)
   dyn_batching = {
@@ -68,7 +68,7 @@ def test_configs(url):
   dyn_batching = {
     'preferred_batch_size': [256]
   }
-  check_config(conf1['config'], 256, ['__ArithmeticGenericOp_2', '__ArithmeticGenericOp_4'], dyn_batching)
+  check_config(conf1['config'], 256, ['DALI_OUTPUT_0', 'DALI_OUTPUT_1'], dyn_batching)
 
 
 def parse_args():

--- a/qa/L0_autoconfig/model_repository/full_autoconfig/1/dali.py
+++ b/qa/L0_autoconfig/model_repository/full_autoconfig/1/dali.py
@@ -30,4 +30,5 @@ from nvidia.dali.plugin.triton import autoserialize
 def pipeline():
   inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0', dtype=dali.types.FLOAT16, ndim=1)
   inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1', dtype=dali.types.FLOAT16, ndim=1)
-  return inp1.gpu() / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
+  return fn.reshape(inp1.gpu() / 3, layout='', name='DALI_OUTPUT_0'), \
+         fn.cast(inp2 / 2, dtype=dali.types.FLOAT, name='DALI_OUTPUT_1')

--- a/qa/L0_autoconfig/model_repository/no_config_file.dali/1/dali.py
+++ b/qa/L0_autoconfig/model_repository/no_config_file.dali/1/dali.py
@@ -30,4 +30,5 @@ from nvidia.dali.plugin.triton import autoserialize
 def pipeline():
   inp1 = fn.external_source(device='cpu', name='DALI_INPUT_0', dtype=dali.types.FLOAT16, ndim=1)
   inp2 = fn.external_source(device='gpu', name='DALI_INPUT_1', dtype=dali.types.FLOAT16, ndim=1)
-  return inp1.gpu() / 3, fn.cast(inp2, dtype=dali.types.FLOAT) / 2
+  return fn.reshape(inp1.gpu() / 3, layout='', name='DALI_OUTPUT_0'), \
+         fn.cast(inp2 / 2, dtype=dali.types.FLOAT, name='DALI_OUTPUT_1')


### PR DESCRIPTION
Autoconfig test was making assumptions on naming of the DALI outputs that weren't guaranteed which resulted in failing tests.

This PR names the pipeline outputs explicitly to make the test reliable.