### PR TITLE
Fix passing extra options to pip install

### DIFF
--- a/src/dali_executor/CMakeLists.txt
+++ b/src/dali_executor/CMakeLists.txt
@@ -37,10 +37,13 @@ if(DALI_VERSION)
     string(APPEND CONF_DOWNLOAD_PKG "==${DALI_VERSION}")
 endif()
 
+separate_arguments(DALI_DOWNLOAD_EXTRA_OPTIONS_LIST UNIX_COMMAND "${DALI_DOWNLOAD_EXTRA_OPTIONS}")
+
 add_custom_command(  # Download and unpack DALI wheel
     OUTPUT dali_whl
     COMMAND
         pip install ${EXTRA_DOWNLOAD_ARGS} --extra-index-url ${DALI_EXTRA_INDEX_URL}
+          ${DALI_DOWNLOAD_EXTRA_OPTIONS_LIST}
           --target ${CMAKE_CURRENT_BINARY_DIR}/dali
           ${DALI_DOWNLOAD_PKG_NAME}$<$<BOOL:${DALI_VERSION}>:==${DALI_VERSION}>
     COMMAND touch dali_whl  # So that this command won't be re-run every time


### PR DESCRIPTION
We need to be able to pass some additional options to pip install when installing DALI. It was missing from the CMake command. 