### PR TITLE
Fix resnet50 ONNX export

### DIFF
--- a/docs/examples/resnet50_trt/onnx_exporter.py
+++ b/docs/examples/resnet50_trt/onnx_exporter.py
@@ -20,28 +20,27 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import torch
-import torchvision.models as models
+from torchvision.models import resnet50, ResNet50_Weights
 import argparse
-import os
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--save", default="model.onnx")
     args = parser.parse_args()
 
-    resnet50 = models.resnet50(pretrained=True)
-    dummy_input = torch.randn(1, 3, 224, 224)
-    resnet50 = resnet50.eval()
+    model = resnet50(weights=ResNet50_Weights.DEFAULT).eval()
+    x = torch.randn(1, 3, 224, 224)
 
-    torch.onnx.export(resnet50,
-                      dummy_input,
-                      args.save,
-                      export_params=True,
-                      opset_version=10,
-                      do_constant_folding=True,
-                      input_names=['input'],
-                      output_names=['output'],
-                      dynamic_axes={'input': {0: 'batch_size', 2: "height", 3: 'width'},
-                                    'output': {0: 'batch_size'}})
-
-    print("Saved {}".format(args.save))
+    torch.onnx.export(
+        model,
+        x,
+        args.save,
+        opset_version=13,
+        dynamo=False,         # legacy exporter
+        input_names=["input"],
+        output_names=["output"],
+        dynamic_axes={
+            "input":  {0: "batch", 2: "height", 3: "width"},
+            "output": {0: "batch"},
+        },
+    )


### PR DESCRIPTION
With the new PyTorch version, the default ONNX exporter changed. I added a flag to keep the legacy exporter for now. Additionally, the opset version needed bumping. 