### PR TITLE
Stop using deprecated tritongrpcclient module

### DIFF
--- a/docs/examples/resnet50_trt/client.py
+++ b/docs/examples/resnet50_trt/client.py
@@ -22,7 +22,7 @@
 import os, sys
 import numpy as np
 import json
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 import argparse
 import time
 

--- a/qa/L0_identity/identity_client.py
+++ b/qa/L0_identity/identity_client.py
@@ -24,7 +24,7 @@
 import argparse, os, sys
 import numpy as np
 from numpy.random import randint
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 from PIL import Image
 import math
 

--- a/qa/L0_identity_cpu/identity_client.py
+++ b/qa/L0_identity_cpu/identity_client.py
@@ -24,7 +24,7 @@
 import argparse, os, sys
 import numpy as np
 from numpy.random import randint
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 from PIL import Image
 import math
 

--- a/qa/L0_many_versions/many_versions_client.py
+++ b/qa/L0_many_versions/many_versions_client.py
@@ -24,7 +24,7 @@
 import argparse, os, sys
 import numpy as np
 from numpy.random import randint
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 from PIL import Image
 import math
 
@@ -71,7 +71,12 @@ def main():
 
     for name, versions in models_not_loaded.items():
         for ver in versions:
-            if triton_client.is_model_ready(name, str(ver)):
+            try:
+                ready = triton_client.is_model_ready(name, str(ver))
+            except Exception:
+                # Newer tritonclient raises NOT_FOUND instead of returning False
+                ready = False
+            if ready:
                 print("FAILED: Model {} version {} incorrectly loaded".format(name, ver))
                 sys.exit(1)
 

--- a/qa/L0_many_versions/many_versions_client.py
+++ b/qa/L0_many_versions/many_versions_client.py
@@ -25,6 +25,7 @@ import argparse, os, sys
 import numpy as np
 from numpy.random import randint
 import tritonclient.grpc as tritongrpcclient
+from tritonclient.utils import InferenceServerException
 from PIL import Image
 import math
 
@@ -73,7 +74,7 @@ def main():
         for ver in versions:
             try:
                 ready = triton_client.is_model_ready(name, str(ver))
-            except Exception:
+            except InferenceServerException:
                 # Newer tritonclient raises NOT_FOUND instead of returning False
                 ready = False
             if ready:

--- a/qa/L0_many_versions/many_versions_client.py
+++ b/qa/L0_many_versions/many_versions_client.py
@@ -66,7 +66,12 @@ def main():
 
     for name, versions in models_loaded.items():
         for ver in versions:
-            if not triton_client.is_model_ready(name, str(ver)):
+            try:
+                ready = triton_client.is_model_ready(name, str(ver))
+            except InferenceServerException:
+                # Newer tritonclient raises NOT_FOUND instead of returning False
+                ready = False
+            if not ready:
                 print("FAILED: Model {} version {} not ready".format(name, ver))
                 sys.exit(1)
 

--- a/qa/L0_resnet50_ensemble/test_client.py
+++ b/qa/L0_resnet50_ensemble/test_client.py
@@ -24,7 +24,7 @@
 import argparse, os, sys
 import numpy as np
 from numpy.random import randint
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 from PIL import Image
 
 np.random.seed(100019)


### PR DESCRIPTION
We were using a depracted module for GRPC client for Triton. Additionally, semantics of one of the functions changed causing test failure. 