### PR TITLE
Make perf analyzer example test deterministic

### DIFF
--- a/qa/L0_perf_analyzer_example/test.sh
+++ b/qa/L0_perf_analyzer_example/test.sh
@@ -49,6 +49,6 @@ awk -F, '
             }
         }
     }
-    END { exit !(valid && rows == 1 && NF >= 3) }
+    END { exit !(valid && rows == 1 && NF == 13) }
 ' results.txt
 echo "Output Correct"

--- a/qa/L0_perf_analyzer_example/test.sh
+++ b/qa/L0_perf_analyzer_example/test.sh
@@ -23,6 +23,32 @@
 
 : ${GRPC_ADDR:=${1:-"localhost:8001"}}
 
-perf_analyzer -m dali -i grpc -u $GRPC_ADDR -b 64 --input-data test_image --shape DALI_INPUT_0:"$(stat --printf='%s' test_image/DALI_INPUT_0)" -f results.txt
-# Test if the perf_analyzer output is in a proper format and the measured times are in a reasonable range.
-[[ "$(tail -n1 results.txt)" =~ ^1,[0-9]{1,}?\.*[0-9]*,([0-9]{1,},){10}[0-9]{1,}$ ]] && echo "Output Correct"
+perf_analyzer \
+    -m dali \
+    -i grpc \
+    -u "$GRPC_ADDR" \
+    -b 64 \
+    --concurrency-range 1 \
+    --request-count 50 \
+    --input-data test_image \
+    --shape DALI_INPUT_0:"$(stat --printf='%s' test_image/DALI_INPUT_0)" \
+    -f results.txt
+
+# Verify the single-concurrency result without imposing a performance threshold.
+awk -F, '
+    BEGIN { valid = 1 }
+    NR == 1 { next }
+    {
+        rows++
+        if ($1 != 1 || $2 !~ /^[0-9]+([.][0-9]+)?$/ || $2 <= 0) {
+            valid = 0
+        }
+        for (field = 3; field <= NF; field++) {
+            if ($field !~ /^[0-9]+([.][0-9]+)?$/) {
+                valid = 0
+            }
+        }
+    }
+    END { exit !(valid && rows == 1 && NF >= 3) }
+' results.txt
+echo "Output Correct"


### PR DESCRIPTION
## Summary

- run perf_analyzer at concurrency 1 for a fixed 50 requests
- validate that it produces exactly one concurrency-1 CSV row with positive throughput and numeric timing values
- remove the integration test's dependency on performance-measurement convergence

## Rationale

L0_perf_analyzer_example is a correctness and integration test, not a performance test. Perf Analyzer's default time-window mode can reject a working integration when measurements do not stabilize within ten windows. A fixed request count still exercises the client, gRPC path, DALI model, batching, and result generation without treating runtime variance as a failure.

## Testing

- bash syntax validation
- controlled Perf Analyzer success path verifies the fixed request-count and concurrency arguments
- malformed, zero-throughput, and multiple-row CSV results are rejected
- Perf Analyzer command failures propagate
- positive-path script probe on the synchronized Linux workstation

The full GPU-backed Triton integration remains covered by CI.