### PR TITLE
Fix OOB read in config.pbtxt parser for unterminated strings

### DIFF
--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,7 @@
 
 #include "src/config_tools/config_tools.h"
 
+#include <algorithm>
 #include <limits>
 
 namespace triton { namespace backend { namespace dali {
@@ -476,7 +477,14 @@ void skip_string(std::string_view &text) {
         ++end;  // escaped character
       ++end;
     }
-    text.remove_prefix(end + 1);
+    // For a well-formed string `end` indexes the closing quote, so we advance
+    // past it with `end + 1`. For an UNTERMINATED string (no closing quote, or
+    // a trailing backslash) `end` can reach or exceed text.size(), and
+    // `end + 1` would then exceed the buffer. std::string_view::remove_prefix
+    // performs no bounds check (it does size_ -= n), so an out-of-range n
+    // underflows size_ to ~SIZE_MAX and the next read walks off the buffer.
+    // Clamp to text.size() to consume the remaining bytes safely instead.
+    text.remove_prefix(std::min(end + 1, text.size()));
     skip_ignored(text);
   }
 }
@@ -531,7 +539,10 @@ std::optional<int64_t> ReadMBSFromPBtxt(std::string_view pb_txt) {
     if (pb_txt.substr(0, field_name.size()) == field_name) {
       pb_txt.remove_prefix(field_name.size());
       skip_ignored(pb_txt);
-      if (pb_txt[0] == ':') {
+      // skip_ignored may consume the rest of the buffer (e.g. a trailing
+      // comment with no newline leaves an empty view), so guard against an
+      // empty view before indexing pb_txt[0].
+      if (!pb_txt.empty() && pb_txt[0] == ':') {
         pb_txt.remove_prefix(1);  // remove :
         return parse_int(pb_txt);
       } else {

--- a/src/config_tools/config_tools.cc
+++ b/src/config_tools/config_tools.cc
@@ -477,13 +477,7 @@ void skip_string(std::string_view &text) {
         ++end;  // escaped character
       ++end;
     }
-    // For a well-formed string `end` indexes the closing quote, so we advance
-    // past it with `end + 1`. For an UNTERMINATED string (no closing quote, or
-    // a trailing backslash) `end` can reach or exceed text.size(), and
-    // `end + 1` would then exceed the buffer. std::string_view::remove_prefix
-    // performs no bounds check (it does size_ -= n), so an out-of-range n
-    // underflows size_ to ~SIZE_MAX and the next read walks off the buffer.
-    // Clamp to text.size() to consume the remaining bytes safely instead.
+    // Consume the closing quote, or the remaining input if it is missing.
     text.remove_prefix(std::min(end + 1, text.size()));
     skip_ignored(text);
   }
@@ -539,9 +533,7 @@ std::optional<int64_t> ReadMBSFromPBtxt(std::string_view pb_txt) {
     if (pb_txt.substr(0, field_name.size()) == field_name) {
       pb_txt.remove_prefix(field_name.size());
       skip_ignored(pb_txt);
-      // skip_ignored may consume the rest of the buffer (e.g. a trailing
-      // comment with no newline leaves an empty view), so guard against an
-      // empty view before indexing pb_txt[0].
+      // skip_ignored may consume the entire remaining input.
       if (!pb_txt.empty() && pb_txt[0] == ':') {
         pb_txt.remove_prefix(1);  // remove :
         return parse_int(pb_txt);

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -1,6 +1,6 @@
 // The MIT License (MIT)
 //
-// Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES
+// Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -703,6 +703,45 @@ TEST_CASE("Read MBS from pb txt") {
       another_string_field: "multiple literals" #interruption }
        "with \"quote\""}
     )");
+
+    REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
+  }
+
+  // TRI-1490: an unterminated quoted string made skip_string() advance `end`
+  // to (or past) text.size() and then call remove_prefix(end + 1) with
+  // end + 1 > size(). string_view::remove_prefix does size_ -= n with no bounds
+  // check, so size_ underflowed to ~SIZE_MAX and the parser read off the end of
+  // the buffer. These inputs must be parsed safely instead of crashing.
+  SECTION("Unterminated string") {
+    std::string_view pb_txt(R"(name: "unterminated_model_name)");
+
+    REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
+  }
+
+  SECTION("Unterminated string with trailing backslash") {
+    // The escape handling (`if (text[end] == '\\') ++end;`) can push `end` one
+    // step further, so remove_prefix(end + 1) overshoots by two.
+    std::string_view pb_txt("name: \"\\");
+
+    REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
+  }
+
+  SECTION("Lone opening quote") {
+    std::string_view pb_txt(R"(")");
+
+    REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
+  }
+
+  SECTION("max_batch_size before an unterminated string is still parsed") {
+    std::string_view pb_txt(R"(max_batch_size: 9 name: "unterminated)");
+
+    REQUIRE(ReadMBSFromPBtxt(pb_txt) == std::make_optional(9));
+  }
+
+  SECTION("Field name followed by comment with no newline") {
+    // skip_ignored consumes the trailing comment and empties the view; without
+    // the empty-view guard the following pb_txt[0] dereferenced a null view.
+    std::string_view pb_txt(R"(max_batch_size #no newline)");
 
     REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
   }

--- a/src/config_tools/config_tools.test.cc
+++ b/src/config_tools/config_tools.test.cc
@@ -707,11 +707,6 @@ TEST_CASE("Read MBS from pb txt") {
     REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
   }
 
-  // TRI-1490: an unterminated quoted string made skip_string() advance `end`
-  // to (or past) text.size() and then call remove_prefix(end + 1) with
-  // end + 1 > size(). string_view::remove_prefix does size_ -= n with no bounds
-  // check, so size_ underflowed to ~SIZE_MAX and the parser read off the end of
-  // the buffer. These inputs must be parsed safely instead of crashing.
   SECTION("Unterminated string") {
     std::string_view pb_txt(R"(name: "unterminated_model_name)");
 
@@ -719,8 +714,6 @@ TEST_CASE("Read MBS from pb txt") {
   }
 
   SECTION("Unterminated string with trailing backslash") {
-    // The escape handling (`if (text[end] == '\\') ++end;`) can push `end` one
-    // step further, so remove_prefix(end + 1) overshoots by two.
     std::string_view pb_txt("name: \"\\");
 
     REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());
@@ -739,8 +732,6 @@ TEST_CASE("Read MBS from pb txt") {
   }
 
   SECTION("Field name followed by comment with no newline") {
-    // skip_ignored consumes the trailing comment and empties the view; without
-    // the empty-view guard the following pb_txt[0] dereferenced a null view.
     std::string_view pb_txt(R"(max_batch_size #no newline)");
 
     REQUIRE(!ReadMBSFromPBtxt(pb_txt).has_value());


### PR DESCRIPTION
The DALI backend parses config.pbtxt with a small hand-written parser
(config_tools.cc). skip_string() doesn't handle a quoted string that never
closes: it scans for the closing quote, runs to the end of the buffer, then
calls remove_prefix(end + 1) with end + 1 > size(). string_view::remove_prefix
has no bounds check (it does size_ -= n), so the length underflows to ~SIZE_MAX
and the next skip walks off the end of the buffer — ASan reports a
heap-buffer-overflow read. It's reachable from any model's config.pbtxt at load
time (e.g. a value like `name: "unterminated`).

Fix: clamp the amount removed to text.size().

While in the same function I also hit a null deref in ReadMBSFromPBtxt: after
matching the field name it calls skip_ignored and then reads pb_txt[0], but
skip_ignored can empty the view (e.g. `max_batch_size` followed by a comment
with no trailing newline), so pb_txt[0] dereferences a null string_view. Added
an empty-view guard.

Both are covered by new Catch2 cases in config_tools.test.cc. I verified before/
after by compiling the parser standalone under -fsanitize=address,undefined: the
old code reproduces the OOB read and the null deref, the new code is clean and
still parses valid configs correctly.
